### PR TITLE
Update default headers to an empty dictionary inside init method

### DIFF
--- a/getstream/config.py
+++ b/getstream/config.py
@@ -2,19 +2,22 @@ from getstream.version import VERSION
 
 
 class BaseConfig:
-    def __init__(self, api_key, base_url=None, token=None, headers={}, anonymous=False,timeout=None,user_agent=None):
+    def __init__(self, api_key, base_url=None, token=None, headers=None, anonymous=False,timeout=None,user_agent=None):
         self.anonymous = anonymous
-        self.timeout=timeout
+        self.timeout = timeout
       
         self.base_url = base_url
         self.params = {"api_key": api_key}
         self.api_key = api_key
+
+        if headers is None:
+            headers = dict()
         if token is not None:
             headers["Authorization"] = token
         if user_agent is None:
             user_agent = self._get_user_agent()
         headers["stream-auth-type"] = self._get_auth_type()
-        headers["X-Stream-Client"] =user_agent
+        headers["X-Stream-Client"] = user_agent
         self.headers = headers
 
     def _get_user_agent(self):


### PR DESCRIPTION
This PR updates the BaseConfig class to address a potential issue with the default parameter headers in the __init__ method.

Previously, the headers parameter had a default value of an empty dictionary {}. However, using a mutable default parameter in Python can lead to unexpected behavior, as modifications made to the dictionary would persist across instance of the class. This could result in sharing state between different instances, which may cause unintended consequences.

To mitigate this issue, the PR modifies the code to assign `None` as the default value for the `headers` parameter. Inside the `__init__` method, it checks if `headers` is `None`, and if so, it assigns a new empty dictionary {} to ensure that each instance of `BaseConfig` has its own separate headers dictionary.

**Changes Made**
    - Modified the `BaseConfig` class's `__init__` method to use None as the default value for the headers parameter.
    - Added a conditional check inside the `__init__` method to assign a new empty dictionary {} to headers if it is `None`.

These changes ensure that the headers dictionary is properly initialized for each instance of BaseConfig, preventing potential issues related to mutable default parameters.

Please review the code changes and let me know if any further modifications are required.