### PR TITLE
WIP cli tool

### DIFF
--- a/getstream/cli/__init__.py
+++ b/getstream/cli/__init__.py
@@ -1,0 +1,52 @@
+import click
+from dotenv import load_dotenv
+
+from getstream import Stream
+from getstream.cli.utils import pass_client
+from getstream.cli.video import video
+from getstream.stream import BASE_URL
+
+
+@click.group()
+@click.option("--api-key")
+@click.option("--api-secret")
+@click.option("--base-url", default=BASE_URL, show_default=True)
+@click.option("--timeout", default=3.0, show_default=True)
+@click.pass_context
+def cli(ctx: click.Context, api_key: str, api_secret: str, base_url: str, timeout=3.0):
+    ctx.ensure_object(dict)
+    ctx.obj["client"] = Stream(
+        api_key=api_key, api_secret=api_secret, timeout=timeout, base_url=base_url
+    )
+
+
+@click.command()
+@click.option("--user-id", required=True)
+@click.option("--call-cid", multiple=True, default=None)
+@click.option("--role", default=None)
+@click.option("--exp-seconds", type=int, default=None)
+@pass_client
+def create_token(
+    client: Stream, user_id: str, call_cid=None, role=None, exp_seconds=None
+):
+    if call_cid is not None and len(call_cid) > 0:
+        print(
+            client.create_call_token(
+                user_id=user_id, call_cids=call_cid, role=role, expiration=exp_seconds
+            )
+        )
+    else:
+        print(client.create_call_token(user_id=user_id))
+
+
+cli.add_command(create_token)
+cli.add_command(video)
+
+
+def main():
+    load_dotenv()
+    cli(auto_envvar_prefix="STREAM", obj={})
+
+
+if __name__ == "__main__":
+    main()

--- a/getstream/cli/utils.py
+++ b/getstream/cli/utils.py
@@ -1,0 +1,21 @@
+from functools import update_wrapper
+import click
+
+
+def pass_client(f):
+    """
+    Decorator that adds the Stream client to the decorated function, with this decorator you can write click commands like this
+
+    @click.command()
+    @click.option("--some-option")
+    @pass_client
+    def do_something(client: Stream, some_option):
+        pass
+
+    """
+
+    @click.pass_context
+    def new_func(ctx, *args, **kwargs):
+        return ctx.invoke(f, ctx.obj["client"], *args, **kwargs)
+
+    return update_wrapper(new_func, f)

--- a/getstream/cli/video.py
+++ b/getstream/cli/video.py
@@ -1,0 +1,52 @@
+import click
+
+from getstream.models import CallRequest
+from getstream import Stream
+import uuid
+from getstream.video.call import Call
+from getstream.cli.utils import pass_client
+
+
+@click.group()
+def video():
+    pass
+
+
+def create_call_command(name, method):
+    # TODO: use reflection to create the correct command
+    # inspect arguments and map them to a click option
+    # scalar types should map to an option
+    # lists of scalars should map to a multiple option
+    # dict/object params should map to a string that we parse from json
+    cmd = click.command(name=name)(method)
+    video.add_command(cmd)
+
+
+call_commands = {
+    "get_call": {"method": Call.get},
+    "delete_call": {"method": Call.delete},
+}
+
+_ = [
+    create_call_command(name, command["method"])
+    for name, command in call_commands.items()
+]
+
+
+@click.command()
+@click.option("--rtmp-user-id", default=f"{uuid.uuid4()}")
+@pass_client
+def rtmp_in_setup(client: Stream, rtmp_user_id: str):
+    call = client.video.call("default", f"rtmp-in-{uuid.uuid4()}").get_or_create(
+        data=CallRequest(
+            created_by_id=rtmp_user_id,
+        ),
+    )
+    print(f"RTMP URL: {call.data.call.ingress.rtmp.address}")
+    print(
+        f"RTMP Stream Token: {client.create_call_token(user_id=rtmp_user_id, call_cids=[call.data.call.cid])}"
+    )
+    print(f"React call link: https://pronto.getstream.io/join/{call.data.call.id}")
+
+
+video.add_command(rtmp_in_setup)

--- a/getstream/models/__init__.py
+++ b/getstream/models/__init__.py
@@ -519,10 +519,19 @@ class BlockUsersRequest(DataClassJsonMixin):
 
 @dataclass
 class BlockUsersResponse(DataClassJsonMixin):
-    duration: str = dc_field(metadata=dc_config(field_name="duration"))
-    blocks: "List[Optional[UserBlock]]" = dc_field(
-        metadata=dc_config(field_name="blocks")
+    blocked_by_user_id: str = dc_field(
+        metadata=dc_config(field_name="blocked_by_user_id")
     )
+    blocked_user_id: str = dc_field(metadata=dc_config(field_name="blocked_user_id"))
+    created_at: datetime = dc_field(
+        metadata=dc_config(
+            field_name="created_at",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        )
+    )
+    duration: str = dc_field(metadata=dc_config(field_name="duration"))
 
 
 @dataclass
@@ -566,6 +575,112 @@ class BroadcastSettingsResponse(DataClassJsonMixin):
 
 
 @dataclass
+class Call(DataClassJsonMixin):
+    app_pk: int = dc_field(metadata=dc_config(field_name="AppPK"))
+    backstage: bool = dc_field(metadata=dc_config(field_name="Backstage"))
+    broadcast_egress: str = dc_field(metadata=dc_config(field_name="BroadcastEgress"))
+    cid: str = dc_field(metadata=dc_config(field_name="CID"))
+    created_at: datetime = dc_field(
+        metadata=dc_config(
+            field_name="CreatedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        )
+    )
+    created_by_user_id: str = dc_field(metadata=dc_config(field_name="CreatedByUserID"))
+    current_session_id: str = dc_field(
+        metadata=dc_config(field_name="CurrentSessionID")
+    )
+    hls_playlist_url: str = dc_field(metadata=dc_config(field_name="HLSPlaylistURL"))
+    id: str = dc_field(metadata=dc_config(field_name="ID"))
+    record_egress: str = dc_field(metadata=dc_config(field_name="RecordEgress"))
+    team: str = dc_field(metadata=dc_config(field_name="Team"))
+    thumbnail_url: str = dc_field(metadata=dc_config(field_name="ThumbnailURL"))
+    transcribe_egress: str = dc_field(metadata=dc_config(field_name="TranscribeEgress"))
+    type: str = dc_field(metadata=dc_config(field_name="Type"))
+    updated_at: datetime = dc_field(
+        metadata=dc_config(
+            field_name="UpdatedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        )
+    )
+    blocked_user_ids: List[str] = dc_field(
+        metadata=dc_config(field_name="BlockedUserIDs")
+    )
+    blocked_users: "List[UserObject]" = dc_field(
+        metadata=dc_config(field_name="BlockedUsers")
+    )
+    members: "List[Optional[CallMember]]" = dc_field(
+        metadata=dc_config(field_name="Members")
+    )
+    sfuids: List[str] = dc_field(metadata=dc_config(field_name="SFUIDs"))
+    custom: Dict[str, object] = dc_field(metadata=dc_config(field_name="Custom"))
+    deleted_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="DeletedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    egress_updated_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="EgressUpdatedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    ended_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="EndedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    last_heartbeat_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="LastHeartbeatAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    starts_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="StartsAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    call_type: "Optional[CallType]" = dc_field(
+        default=None, metadata=dc_config(field_name="CallType")
+    )
+    created_by: "Optional[UserObject]" = dc_field(
+        default=None, metadata=dc_config(field_name="CreatedBy")
+    )
+    session: "Optional[CallSession]" = dc_field(
+        default=None, metadata=dc_config(field_name="Session")
+    )
+    settings: "Optional[CallSettings]" = dc_field(
+        default=None, metadata=dc_config(field_name="Settings")
+    )
+    settings_overrides: "Optional[CallSettings]" = dc_field(
+        default=None, metadata=dc_config(field_name="SettingsOverrides")
+    )
+
+
+@dataclass
 class CallEvent(DataClassJsonMixin):
     description: str = dc_field(metadata=dc_config(field_name="description"))
     end_timestamp: int = dc_field(metadata=dc_config(field_name="end_timestamp"))
@@ -577,6 +692,41 @@ class CallEvent(DataClassJsonMixin):
 @dataclass
 class CallIngressResponse(DataClassJsonMixin):
     rtmp: "RTMPIngress" = dc_field(metadata=dc_config(field_name="rtmp"))
+
+
+@dataclass
+class CallMember(DataClassJsonMixin):
+    created_at: datetime = dc_field(
+        metadata=dc_config(
+            field_name="created_at",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        )
+    )
+    role: str = dc_field(metadata=dc_config(field_name="role"))
+    updated_at: datetime = dc_field(
+        metadata=dc_config(
+            field_name="updated_at",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        )
+    )
+    user_id: str = dc_field(metadata=dc_config(field_name="user_id"))
+    custom: Dict[str, object] = dc_field(metadata=dc_config(field_name="custom"))
+    deleted_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="deleted_at",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    user: "Optional[UserObject]" = dc_field(
+        default=None, metadata=dc_config(field_name="user")
+    )
 
 
 @dataclass
@@ -706,6 +856,97 @@ class CallResponse(DataClassJsonMixin):
     )
     thumbnails: "Optional[ThumbnailResponse]" = dc_field(
         default=None, metadata=dc_config(field_name="thumbnails")
+    )
+
+
+@dataclass
+class CallSession(DataClassJsonMixin):
+    app_pk: int = dc_field(metadata=dc_config(field_name="AppPK"))
+    call_id: str = dc_field(metadata=dc_config(field_name="CallID"))
+    call_type: str = dc_field(metadata=dc_config(field_name="CallType"))
+    created_at: datetime = dc_field(
+        metadata=dc_config(
+            field_name="CreatedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        )
+    )
+    session_id: str = dc_field(metadata=dc_config(field_name="SessionID"))
+    participants: "List[UserObject]" = dc_field(
+        metadata=dc_config(field_name="Participants")
+    )
+    accepted_by: "Dict[str, datetime]" = dc_field(
+        metadata=dc_config(field_name="AcceptedBy")
+    )
+    missed_by: "Dict[str, datetime]" = dc_field(
+        metadata=dc_config(field_name="MissedBy")
+    )
+    rejected_by: "Dict[str, datetime]" = dc_field(
+        metadata=dc_config(field_name="RejectedBy")
+    )
+    deleted_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="DeletedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    ended_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="EndedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    live_ended_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="LiveEndedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    live_started_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="LiveStartedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    ring_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="RingAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    started_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="StartedAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )
+    timer_ends_at: Optional[datetime] = dc_field(
+        default=None,
+        metadata=dc_config(
+            field_name="TimerEndsAt",
+            encoder=encode_datetime,
+            decoder=datetime_from_unix_ns,
+            mm_field=fields.DateTime(format="iso"),
+        ),
     )
 
 
@@ -2269,6 +2510,22 @@ class DeactivateUsersRequest(DataClassJsonMixin):
 class DeactivateUsersResponse(DataClassJsonMixin):
     duration: str = dc_field(metadata=dc_config(field_name="duration"))
     task_id: str = dc_field(metadata=dc_config(field_name="task_id"))
+
+
+@dataclass
+class DeleteCallRequest(DataClassJsonMixin):
+    hard: Optional[bool] = dc_field(default=None, metadata=dc_config(field_name="hard"))
+
+
+@dataclass
+class DeleteCallResponse(DataClassJsonMixin):
+    duration: str = dc_field(metadata=dc_config(field_name="duration"))
+    task_id: Optional[str] = dc_field(
+        default=None, metadata=dc_config(field_name="task_id")
+    )
+    call: "Optional[Call]" = dc_field(
+        default=None, metadata=dc_config(field_name="call")
+    )
 
 
 @dataclass
@@ -7718,22 +7975,6 @@ class UpsertPushProviderResponse(DataClassJsonMixin):
     duration: str = dc_field(metadata=dc_config(field_name="duration"))
     push_provider: "PushProviderResponse" = dc_field(
         metadata=dc_config(field_name="push_provider")
-    )
-
-
-@dataclass
-class UserBlock(DataClassJsonMixin):
-    blocked_by_user_id: str = dc_field(
-        metadata=dc_config(field_name="blocked_by_user_id")
-    )
-    blocked_user_id: str = dc_field(metadata=dc_config(field_name="blocked_user_id"))
-    created_at: datetime = dc_field(
-        metadata=dc_config(
-            field_name="created_at",
-            encoder=encode_datetime,
-            decoder=datetime_from_unix_ns,
-            mm_field=fields.DateTime(format="iso"),
-        )
     )
 
 

--- a/getstream/video/call.py
+++ b/getstream/video/call.py
@@ -72,6 +72,11 @@ class Call:
         self._sync_from_response(response.data)
         return response
 
+    def delete(self, hard: Optional[bool] = None) -> StreamResponse[DeleteCallResponse]:
+        response = self.client.delete_call(type=self.call_type, id=self.id, hard=hard)
+        self._sync_from_response(response.data)
+        return response
+
     def send_call_event(
         self,
         user_id: Optional[str] = None,

--- a/getstream/video/rest_client.py
+++ b/getstream/video/rest_client.py
@@ -148,6 +148,22 @@ class VideoRestClient(BaseClient):
             json=json,
         )
 
+    def delete_call(
+        self, type: str, id: str, hard: Optional[bool] = None
+    ) -> StreamResponse[DeleteCallResponse]:
+        path_params = {
+            "type": type,
+            "id": id,
+        }
+        json = build_body_dict(hard=hard)
+
+        return self.post(
+            "/api/v2/video/call/{type}/{id}/delete",
+            DeleteCallResponse,
+            path_params=path_params,
+            json=json,
+        )
+
     def send_call_event(
         self,
         type: str,

--- a/poetry.lock
+++ b/poetry.lock
@@ -45,6 +45,20 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.7"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -607,4 +621,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "a4506a52588ea3e61f9e094104b901834abc57b76a2e4f49d996b4032eb66822"
+content-hash = "4034560cf3200269a9239613d4f37b0a15a0cbaf2f81ecf7c827440254694a79"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ httpx = "^0.27.0"
 pyjwt = "^2.8.0"
 dataclasses-json = "^0.6.0"
 marshmallow = "^3.21.0"
+click = "^8.1.7"
 
 [tool.poetry.group.dev.dependencies]
 python-dateutil = "^2.8.2"
@@ -32,3 +33,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.ruff.lint]
 ignore = ["F405", "F403"]
+
+[tool.poetry.scripts]
+cli = "getstream.cli:main"


### PR DESCRIPTION
- [ ] Supports nested commands based on product (cli chat create_channel, cli video create_call, cli create_token)
- [ ] Get credentials from args or env vars
- [ ] Automatically generate all CRUD commands based on a index
- [ ] Wrap cli in a docker image so its possible to run it with docker run without using python locally
- [ ] Look into pipx to see if that's a good idea to use it as well (bit faster than docker probably)

Examples:

```bash
STREAM_API_KEY=x STREAM_API_SECRET=z poetry run cli video rtmp-in-setup
```

```bash
STREAM_API_KEY=x STREAM_API_SECRET=z poetry run cli create-token --user-id tommaso --exp-seconds 60 --call-cid default:a --call-cid default:b --role banana
```
