### PR TITLE
fix: Change Elevenlabs to async (streaming) client

### DIFF
--- a/getstream/plugins/elevenlabs/README.md
+++ b/getstream/plugins/elevenlabs/README.md
@@ -42,4 +42,4 @@ await tts.send("Hello, this is a test of the ElevenLabs text-to-speech plugin.")
 ## Requirements
 
 - Python 3.10+
-- elevenlabs>=0.2.0
+- elevenlabs>=2.5.0

--- a/getstream/plugins/elevenlabs/tests/test_tts.py
+++ b/getstream/plugins/elevenlabs/tests/test_tts.py
@@ -18,19 +18,24 @@ class MockAudioTrack(AudioStreamTrack):
         return True
 
 
-# Mock ElevenLabs client for testing
-class MockElevenLabsClient:
+# Mock AsyncElevenLabs client for testing
+class MockAsyncElevenLabsClient:
     def __init__(self, api_key=None):
         self.api_key = api_key
         self.text_to_speech = MagicMock()
 
         # Create a mock audio stream that returns a few chunks of audio
         mock_audio = [b"\x00\x00" * 1000, b"\x00\x00" * 1000]
-        self.text_to_speech.stream = MagicMock(return_value=iter(mock_audio))
+        
+        # Mock the async stream method
+        async def mock_stream(*args, **kwargs):
+            return iter(mock_audio)
+        
+        self.text_to_speech.stream = mock_stream
 
 
 @pytest.mark.asyncio
-@patch("elevenlabs.client.ElevenLabs", MockElevenLabsClient)
+@patch("elevenlabs.client.AsyncElevenLabs", MockAsyncElevenLabsClient)
 async def test_elevenlabs_tts_initialization():
     """Test that the ElevenLabs TTS initializes correctly with explicit API key."""
     tts = ElevenLabsTTS(api_key="test-api-key")
@@ -39,7 +44,7 @@ async def test_elevenlabs_tts_initialization():
 
 
 @pytest.mark.asyncio
-@patch("elevenlabs.client.ElevenLabs", MockElevenLabsClient)
+@patch("elevenlabs.client.AsyncElevenLabs", MockAsyncElevenLabsClient)
 @patch.dict(os.environ, {"ELEVENLABS_API_KEY": "env-var-api-key"})
 async def test_elevenlabs_tts_initialization_with_env_var():
     """ElevenLabsTTS should use ELEVENLABS_API_KEY when no key argument is given."""
@@ -50,7 +55,7 @@ async def test_elevenlabs_tts_initialization_with_env_var():
 
 
 @pytest.mark.asyncio
-@patch("elevenlabs.client.ElevenLabs", MockElevenLabsClient)
+@patch("elevenlabs.client.AsyncElevenLabs", MockAsyncElevenLabsClient)
 async def test_elevenlabs_tts_synthesize():
     """Test that synthesize returns an audio stream."""
     tts = ElevenLabsTTS(api_key="test-api-key")
@@ -69,7 +74,7 @@ async def test_elevenlabs_tts_synthesize():
 
 
 @pytest.mark.asyncio
-@patch("elevenlabs.client.ElevenLabs", MockElevenLabsClient)
+@patch("elevenlabs.client.AsyncElevenLabs", MockAsyncElevenLabsClient)
 async def test_elevenlabs_tts_send():
     """Test that send writes audio to the track and emits events."""
     tts = ElevenLabsTTS(api_key="test-api-key")
@@ -98,7 +103,7 @@ async def test_elevenlabs_tts_send():
 
 
 @pytest.mark.asyncio
-@patch("elevenlabs.client.ElevenLabs", MockElevenLabsClient)
+@patch("elevenlabs.client.AsyncElevenLabs", MockAsyncElevenLabsClient)
 async def test_elevenlabs_tts_send_without_track():
     """Test that sending without setting a track raises an error."""
     tts = ElevenLabsTTS(api_key="test-api-key")
@@ -109,7 +114,7 @@ async def test_elevenlabs_tts_send_without_track():
 
 
 @pytest.mark.asyncio
-@patch("elevenlabs.client.ElevenLabs", MockElevenLabsClient)
+@patch("elevenlabs.client.AsyncElevenLabs", MockAsyncElevenLabsClient)
 async def test_elevenlabs_tts_invalid_framerate():
     """Test that setting a track with invalid framerate raises an error."""
     tts = ElevenLabsTTS(api_key="test-api-key")

--- a/getstream/plugins/elevenlabs/tests/test_tts.py
+++ b/getstream/plugins/elevenlabs/tests/test_tts.py
@@ -26,11 +26,11 @@ class MockAsyncElevenLabsClient:
 
         # Create a mock audio stream that returns a few chunks of audio
         mock_audio = [b"\x00\x00" * 1000, b"\x00\x00" * 1000]
-        
+
         # Mock the async stream method
         async def mock_stream(*args, **kwargs):
             return iter(mock_audio)
-        
+
         self.text_to_speech.stream = mock_stream
 
 
@@ -133,7 +133,8 @@ async def test_elevenlabs_with_real_api():
     """
     Integration test with the real ElevenLabs API.
 
-    This test uses the actual ElevenLabs API with the ELEVENLABS_API_KEY environment variable.
+    This test uses the actual ElevenLabs API with the
+    ELEVENLABS_API_KEY environment variable.
     It will be skipped if the environment variable is not set.
 
     To set up the ELEVENLABS_API_KEY:
@@ -147,7 +148,8 @@ async def test_elevenlabs_with_real_api():
     # Skip the test if the ELEVENLABS_API_KEY environment variable is not set
     if not api_key:
         pytest.skip(
-            "ELEVENLABS_API_KEY environment variable not set. Add it to your .env file."
+            "ELEVENLABS_API_KEY environment variable not set. "
+            "Add it to your .env file."
         )
 
     # Create a real ElevenLabs TTS instance with the API key explicitly set

--- a/getstream/plugins/elevenlabs/tts/tts.py
+++ b/getstream/plugins/elevenlabs/tts/tts.py
@@ -21,13 +21,13 @@ class ElevenLabsTTS(TTS):
             model_id: The model ID to use for synthesis
         """
         super().__init__()
-        from elevenlabs.client import ElevenLabs
+        from elevenlabs.client import AsyncElevenLabs
 
         # elevenlabs sdk does not always load the env correctly (default kwarg)
         if not api_key:
             api_key = os.environ.get("ELEVENLABS_API_KEY")
 
-        self.client = ElevenLabs(api_key=api_key)
+        self.client = AsyncElevenLabs(api_key=api_key)
         self.voice_id = voice_id
         self.model_id = model_id
         self.output_format = "pcm_16000"
@@ -47,7 +47,7 @@ class ElevenLabsTTS(TTS):
         Returns:
             An iterator of audio chunks as bytes
         """
-        audio_stream = self.client.text_to_speech.stream(
+        audio_stream = await self.client.text_to_speech.stream(
             text=text,
             voice_id=self.voice_id,
             output_format=self.output_format,

--- a/getstream/plugins/elevenlabs/tts/tts.py
+++ b/getstream/plugins/elevenlabs/tts/tts.py
@@ -47,7 +47,7 @@ class ElevenLabsTTS(TTS):
         Returns:
             An async iterator of audio chunks as bytes
         """
-        audio_stream = await self.client.text_to_speech.stream(
+        audio_stream = self.client.text_to_speech.stream(
             text=text,
             voice_id=self.voice_id,
             output_format=self.output_format,

--- a/getstream/plugins/elevenlabs/tts/tts.py
+++ b/getstream/plugins/elevenlabs/tts/tts.py
@@ -1,6 +1,6 @@
 from getstream.plugins.common import TTS
 from getstream.video.rtc.audio_track import AudioStreamTrack
-from typing import Iterator, Optional
+from typing import AsyncIterator, Optional
 import os
 
 
@@ -37,7 +37,7 @@ class ElevenLabsTTS(TTS):
             raise TypeError("Invalid framerate, audio track only supports 16000")
         super().set_output_track(track)
 
-    async def synthesize(self, text: str, *args, **kwargs) -> Iterator[bytes]:
+    async def synthesize(self, text: str, *args, **kwargs) -> AsyncIterator[bytes]:
         """
         Convert text to speech using ElevenLabs API.
 
@@ -45,7 +45,7 @@ class ElevenLabsTTS(TTS):
             text: The text to convert to speech
 
         Returns:
-            An iterator of audio chunks as bytes
+            An async iterator of audio chunks as bytes
         """
         audio_stream = await self.client.text_to_speech.stream(
             text=text,


### PR DESCRIPTION
The ElevenLabs plugin was using the synchronous client, changed it over to the asynchronous client which should stream audio chunks as they come in.