### PR TITLE
STT Threading 

### DIFF
--- a/getstream/plugins/deepgram/stt/stt.py
+++ b/getstream/plugins/deepgram/stt/stt.py
@@ -62,7 +62,15 @@ class DeepgramSTT(STT):
                                 Default is 5.0 seconds (recommended value by Deepgram)
             interim_results: Whether to emit interim results (partial transcripts with the partial_transcript event).
         """
-        super().__init__(sample_rate=sample_rate)
+
+        # Capture the current event loop to ensure proper thread-safe event emission
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        
+        # Pass the loop to the parent class to handle cross-thread event emission
+        super().__init__(sample_rate=sample_rate, language=language, loop=loop)
 
         # Check if deepgram is available
         if not _deepgram_available:


### PR DESCRIPTION
In our Deepgram plugin, we are trying to emit events from a background thread which is not passed to the `init`. `AsyncIOEventEmitter` as a result sometimes fails to schedule callbacks on the correct event loop. 

