### PR TITLE
chore: upgrade httpx dependency to support 0.28.x versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.9,<4.0.0"
 readme = "README.md"
 dependencies = [
-    "httpx>=0.27.0,<0.28",
+    "httpx>=0.27.0,<0.29",
     "pyjwt>=2.8.0,<3",
     "dataclasses-json>=0.6.0,<0.7",
     "marshmallow>=3.21.0,<4",


### PR DESCRIPTION
## Summary
- Updates httpx dependency constraint from `<0.28` to `<0.29` to allow installation of httpx 0.28.1 and other 0.28.x versions
- Maintains backward compatibility with existing 0.27.x versions
- Tested import functionality with httpx 0.28.1 successfully

## Test plan
- [x] Verified package installs successfully with httpx 0.28.1
- [x] Confirmed basic import functionality works
- [x] Tested REST client imports

🤖 Generated with [Claude Code](https://claude.ai/code)