### PR TITLE
[AI-148] Expose the user agent

### DIFF
--- a/getstream/base.py
+++ b/getstream/base.py
@@ -118,12 +118,14 @@ class BaseClient(TelemetryEndpointMixin, BaseConfig, ResponseParserMixin, ABC):
         base_url=None,
         token=None,
         timeout=None,
+        user_agent=None,
     ):
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             token=token,
             timeout=timeout,
+            user_agent=user_agent,
         )
         self.client = httpx.Client(
             base_url=self.base_url,
@@ -280,12 +282,14 @@ class AsyncBaseClient(TelemetryEndpointMixin, BaseConfig, ResponseParserMixin, A
         base_url=None,
         token=None,
         timeout=None,
+        user_agent=None,
     ):
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             token=token,
             timeout=timeout,
+            user_agent=user_agent,
         )
         self.client = httpx.AsyncClient(
             base_url=self.base_url,

--- a/getstream/chat/async_client.py
+++ b/getstream/chat/async_client.py
@@ -3,9 +3,9 @@ from getstream.chat.async_rest_client import ChatRestClient
 
 
 class ChatClient(ChatRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout, stream):
+    def __init__(self, api_key: str, base_url, token, timeout, stream, user_agent=None):
         super().__init__(
-            api_key=api_key, base_url=base_url, token=token, timeout=timeout
+            api_key=api_key, base_url=base_url, token=token, timeout=timeout, user_agent=user_agent
         )
         self.stream = stream
 

--- a/getstream/chat/async_rest_client.py
+++ b/getstream/chat/async_rest_client.py
@@ -7,19 +7,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class ChatRestClient(AsyncBaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes ChatClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     @telemetry.operation_name("getstream.api.chat.query_campaigns")

--- a/getstream/chat/client.py
+++ b/getstream/chat/client.py
@@ -3,9 +3,9 @@ from getstream.chat.rest_client import ChatRestClient
 
 
 class ChatClient(ChatRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout, stream):
+    def __init__(self, api_key: str, base_url, token, timeout, stream, user_agent=None):
         super().__init__(
-            api_key=api_key, base_url=base_url, token=token, timeout=timeout
+            api_key=api_key, base_url=base_url, token=token, timeout=timeout, user_agent=user_agent
         )
         self.stream = stream
 

--- a/getstream/chat/rest_client.py
+++ b/getstream/chat/rest_client.py
@@ -7,19 +7,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class ChatRestClient(BaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes ChatClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     @telemetry.operation_name("getstream.api.chat.query_campaigns")

--- a/getstream/common/async_client.py
+++ b/getstream/common/async_client.py
@@ -2,7 +2,7 @@ from getstream.common.async_rest_client import CommonRestClient
 
 
 class CommonClient(CommonRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout):
+    def __init__(self, api_key: str, base_url, token, timeout, user_agent=None):
         super().__init__(
-            api_key=api_key, base_url=base_url, token=token, timeout=timeout
+            api_key=api_key, base_url=base_url, token=token, timeout=timeout, user_agent=user_agent
         )

--- a/getstream/common/async_rest_client.py
+++ b/getstream/common/async_rest_client.py
@@ -7,19 +7,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class CommonRestClient(AsyncBaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes CommonClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     @telemetry.operation_name("getstream.api.common.get_app")

--- a/getstream/common/client.py
+++ b/getstream/common/client.py
@@ -2,7 +2,7 @@ from getstream.common.rest_client import CommonRestClient
 
 
 class CommonClient(CommonRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout):
+    def __init__(self, api_key: str, base_url, token, timeout, user_agent=None):
         super().__init__(
-            api_key=api_key, base_url=base_url, token=token, timeout=timeout
+            api_key=api_key, base_url=base_url, token=token, timeout=timeout, user_agent=user_agent
         )

--- a/getstream/common/rest_client.py
+++ b/getstream/common/rest_client.py
@@ -7,19 +7,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class CommonRestClient(BaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes CommonClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     @telemetry.operation_name("getstream.api.common.get_app")

--- a/getstream/feeds/client.py
+++ b/getstream/feeds/client.py
@@ -4,9 +4,9 @@ from typing import Optional, Dict
 
 
 class FeedsClient(FeedsRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout, stream):
+    def __init__(self, api_key: str, base_url, token, timeout, stream, user_agent=None):
         super().__init__(
-            api_key=api_key, base_url=base_url, token=token, timeout=timeout
+            api_key=api_key, base_url=base_url, token=token, timeout=timeout, user_agent=user_agent
         )
         self.stream = stream
 

--- a/getstream/feeds/rest_client.py
+++ b/getstream/feeds/rest_client.py
@@ -6,19 +6,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class FeedsRestClient(BaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes FeedsClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     def add_activity(

--- a/getstream/moderation/async_client.py
+++ b/getstream/moderation/async_client.py
@@ -2,8 +2,8 @@ from getstream.moderation.async_rest_client import ModerationRestClient
 
 
 class ModerationClient(ModerationRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout, stream):
+    def __init__(self, api_key: str, base_url, token, timeout, stream, user_agent=None):
         super().__init__(
-            api_key=api_key, base_url=base_url, token=token, timeout=timeout
+            api_key=api_key, base_url=base_url, token=token, timeout=timeout, user_agent=user_agent
         )
         self.stream = stream

--- a/getstream/moderation/async_rest_client.py
+++ b/getstream/moderation/async_rest_client.py
@@ -7,19 +7,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class ModerationRestClient(AsyncBaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes ModerationClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     @telemetry.operation_name("getstream.api.moderation.ban")

--- a/getstream/moderation/client.py
+++ b/getstream/moderation/client.py
@@ -2,8 +2,8 @@ from getstream.moderation.rest_client import ModerationRestClient
 
 
 class ModerationClient(ModerationRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout, stream):
+    def __init__(self, api_key: str, base_url, token, timeout, stream, user_agent=None):
         super().__init__(
-            api_key=api_key, base_url=base_url, token=token, timeout=timeout
+            api_key=api_key, base_url=base_url, token=token, timeout=timeout, user_agent=user_agent
         )
         self.stream = stream

--- a/getstream/moderation/rest_client.py
+++ b/getstream/moderation/rest_client.py
@@ -7,19 +7,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class ModerationRestClient(BaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes ModerationClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     @telemetry.operation_name("getstream.api.moderation.ban")

--- a/getstream/stream.py
+++ b/getstream/stream.py
@@ -45,6 +45,7 @@ class BaseStream:
         api_secret: Optional[str] = None,
         timeout: Optional[float] = 6.0,
         base_url: Optional[str] = BASE_URL,
+        user_agent: Optional[str] = None,
     ):
         if None in (api_key, api_secret, timeout, base_url):
             s = Settings()  # loads from env and optional .env
@@ -65,8 +66,9 @@ class BaseStream:
         self.timeout = timeout
 
         self.base_url = validate_and_clean_url(base_url)
+        self.user_agent = user_agent
         self.token = self._create_token()
-        super().__init__(self.api_key, self.base_url, self.token, self.timeout)
+        super().__init__(self.api_key, self.base_url, self.token, self.timeout, self.user_agent)
 
     def create_token(
         self,
@@ -162,6 +164,7 @@ class AsyncStream(BaseStream, AsyncCommonClient):
             token=self.token,
             timeout=self.timeout,
             stream=self,
+            user_agent=self.user_agent,
         )
 
     @cached_property
@@ -176,6 +179,7 @@ class AsyncStream(BaseStream, AsyncCommonClient):
             token=self.token,
             timeout=self.timeout,
             stream=self,
+            user_agent=self.user_agent,
         )
 
     @cached_property
@@ -190,6 +194,7 @@ class AsyncStream(BaseStream, AsyncCommonClient):
             token=self.token,
             timeout=self.timeout,
             stream=self,
+            user_agent=self.user_agent,
         )
 
     @cached_property
@@ -249,6 +254,7 @@ class Stream(BaseStream, CommonClient):
             api_secret=self.api_secret,
             timeout=self.timeout,
             base_url=self.base_url,
+            user_agent=self.user_agent,
         )
 
     @cached_property
@@ -263,6 +269,7 @@ class Stream(BaseStream, CommonClient):
             token=self.token,
             timeout=self.timeout,
             stream=self,
+            user_agent=self.user_agent,
         )
 
     @cached_property
@@ -277,6 +284,7 @@ class Stream(BaseStream, CommonClient):
             token=self.token,
             timeout=self.timeout,
             stream=self,
+            user_agent=self.user_agent,
         )
 
     @cached_property
@@ -291,6 +299,7 @@ class Stream(BaseStream, CommonClient):
             token=self.token,
             timeout=self.timeout,
             stream=self,
+            user_agent=self.user_agent,
         )
 
     @cached_property
@@ -305,6 +314,7 @@ class Stream(BaseStream, CommonClient):
             token=self.token,
             timeout=self.timeout,
             stream=self,
+            user_agent=self.user_agent,
         )
 
     @telemetry.operation_name("getstream.api.common.create_user")

--- a/getstream/video/async_client.py
+++ b/getstream/video/async_client.py
@@ -3,19 +3,21 @@ from getstream.video.async_call import Call
 
 
 class VideoClient(VideoRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout, stream):
+    def __init__(self, api_key: str, base_url, token, timeout, stream, user_agent=None):
         """
         Initializes VideoClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param token: A string instance representing the client's token
         :param timeout: A number representing the time limit for a request
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             token=token,
             timeout=timeout,
+            user_agent=user_agent,
         )
         self.stream = stream
 

--- a/getstream/video/async_rest_client.py
+++ b/getstream/video/async_rest_client.py
@@ -7,19 +7,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class VideoRestClient(AsyncBaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes VideoClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     @telemetry.operation_name("getstream.api.video.get_active_calls_status")

--- a/getstream/video/client.py
+++ b/getstream/video/client.py
@@ -3,19 +3,21 @@ from getstream.video.call import Call
 
 
 class VideoClient(VideoRestClient):
-    def __init__(self, api_key: str, base_url, token, timeout, stream):
+    def __init__(self, api_key: str, base_url, token, timeout, stream, user_agent=None):
         """
         Initializes VideoClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param token: A string instance representing the client's token
         :param timeout: A number representing the time limit for a request
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             token=token,
             timeout=timeout,
+            user_agent=user_agent,
         )
         self.stream = stream
 

--- a/getstream/video/rest_client.py
+++ b/getstream/video/rest_client.py
@@ -7,19 +7,21 @@ from getstream.utils import build_query_param, build_body_dict
 
 
 class VideoRestClient(BaseClient):
-    def __init__(self, api_key: str, base_url: str, timeout: float, token: str):
+    def __init__(self, api_key: str, base_url: str, timeout: float, token: str, user_agent: str = None):
         """
         Initializes VideoClient with BaseClient instance
         :param api_key: A string representing the client's API key
         :param base_url: A string representing the base uniform resource locator
         :param timeout: A number representing the time limit for a request
         :param token: A string instance representing the client's token
+        :param user_agent: Optional custom user agent string
         """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             token=token,
+            user_agent=user_agent,
         )
 
     @telemetry.operation_name("getstream.api.video.get_active_calls_status")


### PR DESCRIPTION
For Stream Agent, we need a way to set a custom user agent so we're able to track API calls and usage via Nessy. This PR exposes the user agent while keeping the default.