### PR TITLE
Better exception

### DIFF
--- a/getstream/video/rtc/connection_manager.py
+++ b/getstream/video/rtc/connection_manager.py
@@ -329,12 +329,12 @@ class ConnectionManager(StreamAsyncIOEventEmitter):
                         sfu_event.join_response.fast_reconnect_deadline_seconds
                     )
             else:
-                logger.warning(f"No join response from WebSocket: {sfu_event}")
+                logger.exception(f"No join response from WebSocket: {sfu_event}")
 
             logger.debug(f"WebSocket connected successfully to {ws_url}")
         except Exception as e:
-            logger.error(f"Failed to connect WebSocket to {ws_url}: {e}")
-            raise SfuConnectionError(f"WebSocket connection failed: {e}")
+            logger.exception(f"Failed to connect WebSocket to {ws_url}: {e}")
+            raise SfuConnectionError(f"WebSocket connection failed: {e}") from e
 
         # Step 5: Create SFU signaling client
         twirp_server_url = self.join_response.data.credentials.server.url

--- a/getstream/video/rtc/connection_utils.py
+++ b/getstream/video/rtc/connection_utils.py
@@ -220,7 +220,10 @@ async def create_join_request(token: str, session_id: str) -> events_pb2.JoinReq
         A JoinRequest protobuf message configured with data
     """
 
-    from video.rtc.pc import subscribe_codec_preferences, publish_codec_preferences
+    from getstream.video.rtc.pc import (
+        subscribe_codec_preferences,
+        publish_codec_preferences,
+    )
 
     # Create a JoinRequest
     join_request = events_pb2.JoinRequest()


### PR DESCRIPTION
- make sure the original stacktrace is kept when re-raising 
- fix import err (only happens when using the lib from another project)