### PR TITLE
Replace `twirp.context.Context` with a wrapper class to fix the logging issue

### DIFF
--- a/getstream/video/rtc/connection_manager.py
+++ b/getstream/video/rtc/connection_manager.py
@@ -6,7 +6,6 @@ from typing import Optional, Dict, Any
 
 import aioice
 import aiortc
-from twirp.context import Context
 
 from getstream.common import telemetry
 from getstream.utils import StreamAsyncIOEventEmitter
@@ -14,7 +13,7 @@ from getstream.video.rtc.coordinator.ws import StreamAPIWS
 from getstream.video.rtc.pb.stream.video.sfu.event import events_pb2
 from getstream.video.rtc.pb.stream.video.sfu.models import models_pb2
 from getstream.video.rtc.pb.stream.video.sfu.signal_rpc import signal_pb2
-from getstream.video.rtc.twirp_client_wrapper import SfuRpcError, SignalClient
+from getstream.video.rtc.twirp_client_wrapper import SfuRpcError, SignalClient, Context
 
 from getstream.video.async_call import Call
 from getstream.video.rtc.connection_utils import (

--- a/tests/test_twirp_client_wrapper.py
+++ b/tests/test_twirp_client_wrapper.py
@@ -6,12 +6,11 @@ from unittest.mock import AsyncMock, patch, MagicMock
 # import twirp.async_client # <-- REMOVE THIS DEBUG IMPORT
 
 # Modules to test
-from getstream.video.rtc.twirp_client_wrapper import SignalClient, SfuRpcError
+from getstream.video.rtc.twirp_client_wrapper import SignalClient, SfuRpcError, Context
 
 # Protobufs needed for requests/responses and error codes
 from getstream.video.rtc.pb.stream.video.sfu.signal_rpc import signal_pb2
 from getstream.video.rtc.pb.stream.video.sfu.models import models_pb2
-from twirp.context import Context
 
 # No longer need to patch the base class path
 # ASYNC_CLIENT_PATH = "getstream.video.rtc.twirp_client_wrapper.AsyncSignalServerClient"


### PR DESCRIPTION
# Problem 
The code in `twirp.logging.configure()` sets the root logger's log level to INFO (the default is WARNING). 
It makes INFO log messages from other libs visible by default, which creates noise.

This code is called when `twirp.context.Context` is created for the first time, unless the `logger` argument is provided to it. 

# Solution
1. Added a custom `video.rtc.twirp_client_wrapper.Context` subclass that always provides the default logger, so the root logger remains intact.
2. Replaced the usages of `twirp.context.Context` with `video.rtc.twirp_client_wrapper.Context` class


