### PR TITLE
Fix BufferedMediaTrack.stop()

### DIFF
--- a/getstream/video/rtc/track_util.py
+++ b/getstream/video/rtc/track_util.py
@@ -1775,9 +1775,9 @@ class BufferedMediaTrack(aiortc.mediastreams.MediaStreamTrack):
             self._ended = True
             self._buffered_frames = []  # Clear all buffered frames
             # Stop the underlying track if it has a stop method
-            if hasattr(self._track, "stop_audio"):
+            if hasattr(self._track, "stop"):
                 try:
-                    self._track.stop_audio()
+                    self._track.stop()
                 except Exception as e:
                     logger.error(f"Error stopping track: {e}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media track shutdown logic to more reliably stop underlying tracks and reduce cleanup errors.
  * No changes to public APIs or interfaces—behavioral fixes only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->