### PR TITLE
Re-emit track_published events for already published tracks after connecting to SFU

### DIFF
--- a/getstream/video/rtc/connection_manager.py
+++ b/getstream/video/rtc/connection_manager.py
@@ -381,10 +381,6 @@ class ConnectionManager(StreamAsyncIOEventEmitter):
             self._coordinator_task.add_done_callback(_on_coordinator_task_done)
         await self._connect_internal()
 
-        # Re-publish the already published tracks because
-        # SFU doesn't send events for them.
-        await self._republish_existing_tracks()
-
     async def wait(self):
         """
         Wait until the connection is over.
@@ -538,12 +534,12 @@ class ConnectionManager(StreamAsyncIOEventEmitter):
         except Exception as e:
             logger.error("Failed to restore published tracks", exc_info=e)
 
-    async def _republish_existing_tracks(self) -> None:
+    async def republish_tracks(self) -> None:
         """
         Use the participants info from the SFU to re-emit the "track_published"
         events for the already published tracks.
 
-        It's needed because SFU does not send the events for those when the
+        It's needed because SFU does not send the events for the already present tracks when the
         agent joins after the user.
         """
 


### PR DESCRIPTION
**Problem:** `track_published` events are not always emitted for the already published tracks with the participant joins.

Without these events, the video track may never be discovered by the participants who joined later. 


This PR re-emits `track_published` events after the WS connection is established to force the track update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public async method to re-announce already-published tracks so existing participant tracks can be propagated on demand.

* **Bug Fixes**
  * Restored visibility of tracks for late-joining participants: previously-published tracks are replayed and become observable when joining an ongoing session.
  * Improved event propagation on connect: the connection now forwards session events after establishing the socket so session state is reconstructed reliably on join.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->