### PR TITLE
fix: stop video drain when real subscriber arrives

### DIFF
--- a/getstream/video/rtc/connection_manager.py
+++ b/getstream/video/rtc/connection_manager.py
@@ -58,7 +58,7 @@ class ConnectionManager(StreamAsyncIOEventEmitter):
         create: bool = True,
         subscription_config: Optional[SubscriptionConfig] = None,
         max_join_retries: int = 3,
-        drain_video_frames: bool = False,
+        drain_video_frames: bool = True,
         **kwargs: Any,
     ):
         super().__init__()

--- a/getstream/video/rtc/connection_manager.py
+++ b/getstream/video/rtc/connection_manager.py
@@ -61,6 +61,15 @@ class ConnectionManager(StreamAsyncIOEventEmitter):
         drain_video_frames: bool = True,
         **kwargs: Any,
     ):
+        """
+        Args:
+            drain_video_frames: When True, attaches a MediaBlackhole to each
+                incoming video track so unconsumed frames are drained
+                automatically. This prevents unbounded queue growth in
+                RTCRtpReceiver when no subscriber is consuming the track.
+                The drain is stopped once a real subscriber is added via
+                add_track_subscriber.
+        """
         super().__init__()
 
         # Public attributes

--- a/getstream/video/rtc/pc.py
+++ b/getstream/video/rtc/pc.py
@@ -133,15 +133,6 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
         configuration: aiortc.RTCConfiguration,
         drain_video_frames: bool = True,
     ) -> None:
-        """
-        Args:
-            drain_video_frames: When True, attaches a MediaBlackhole to each
-                incoming video track so unconsumed frames are drained
-                automatically. This prevents unbounded queue growth in
-                RTCRtpReceiver when no subscriber is consuming the track.
-                The drain is stopped once a real subscriber is added via
-                add_track_subscriber.
-        """
         logger.info(
             f"creating subscriber peer connection with configuration: {configuration}"
         )

--- a/getstream/video/rtc/pc.py
+++ b/getstream/video/rtc/pc.py
@@ -133,6 +133,15 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
         configuration: aiortc.RTCConfiguration,
         drain_video_frames: bool = True,
     ) -> None:
+        """
+        Args:
+            drain_video_frames: When True, attaches a MediaBlackhole to each
+                incoming video track so unconsumed frames are drained
+                automatically. This prevents unbounded queue growth in
+                RTCRtpReceiver when no subscriber is consuming the track.
+                The drain is stopped once a real subscriber is added via
+                add_track_subscriber.
+        """
         logger.info(
             f"creating subscriber peer connection with configuration: {configuration}"
         )

--- a/getstream/video/rtc/pc.py
+++ b/getstream/video/rtc/pc.py
@@ -144,6 +144,7 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
         self.video_frame_trackers = {}  # track_id -> VideoFrameTracker
         self._video_blackholes: dict[str, MediaBlackhole] = {}
         self._video_drain_tasks: dict[str, asyncio.Task] = {}
+        self._background_tasks: set[asyncio.Task] = set()
 
         @self.on("track")
         async def on_track(track: aiortc.mediastreams.MediaStreamTrack):
@@ -212,7 +213,9 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
         blackhole = self._video_blackholes.pop(track_id, None)
 
         if blackhole:
-            asyncio.ensure_future(blackhole.stop())
+            task = asyncio.create_task(blackhole.stop())
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
         if track_data:
             relay, original_track = track_data

--- a/getstream/video/rtc/pc.py
+++ b/getstream/video/rtc/pc.py
@@ -205,10 +205,11 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
         """Add a new subscriber to an existing track's MediaRelay."""
         track_data = self.track_map.get(track_id)
 
-        blackhole, _ = self._video_blackholes.pop(track_id, (None, None))
+        blackhole, drain_task = self._video_blackholes.pop(track_id, (None, None))
 
-        if blackhole:
+        if blackhole and drain_task:
             task = asyncio.create_task(blackhole.stop())
+            drain_task.cancel()  # safety net if start() becomes long-lived in future aiortc
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
 

--- a/getstream/video/rtc/pc.py
+++ b/getstream/video/rtc/pc.py
@@ -131,7 +131,7 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
         self,
         connection,
         configuration: aiortc.RTCConfiguration,
-        drain_video_frames: bool = False,
+        drain_video_frames: bool = True,
     ) -> None:
         logger.info(
             f"creating subscriber peer connection with configuration: {configuration}"
@@ -207,6 +207,12 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
     ) -> Optional[aiortc.mediastreams.MediaStreamTrack]:
         """Add a new subscriber to an existing track's MediaRelay."""
         track_data = self.track_map.get(track_id)
+
+        self._video_drain_tasks.pop(track_id, None)
+        blackhole = self._video_blackholes.pop(track_id, None)
+
+        if blackhole:
+            asyncio.ensure_future(blackhole.stop())
 
         if track_data:
             relay, original_track = track_data

--- a/getstream/video/rtc/pc.py
+++ b/getstream/video/rtc/pc.py
@@ -142,8 +142,7 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
 
         self.track_map = {}  # track_id -> (MediaRelay, original_track)
         self.video_frame_trackers = {}  # track_id -> VideoFrameTracker
-        self._video_blackholes: dict[str, MediaBlackhole] = {}
-        self._video_drain_tasks: dict[str, asyncio.Task] = {}
+        self._video_blackholes: dict[str, tuple[MediaBlackhole, asyncio.Task]] = {}
         self._background_tasks: set[asyncio.Task] = set()
 
         @self.on("track")
@@ -190,11 +189,8 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
                 drain_proxy = relay.subscribe(tracked_track)
                 blackhole = MediaBlackhole()
                 blackhole.addTrack(drain_proxy)
-                self._video_blackholes[track.id] = blackhole
-                self._video_drain_tasks[track.id] = asyncio.create_task(
-                    blackhole.start()
-                )
-
+                drain_task = asyncio.create_task(blackhole.start())
+                self._video_blackholes[track.id] = (blackhole, drain_task)
             self.emit("track_added", proxy, user)
 
         @self.on("icegatheringstatechange")
@@ -209,8 +205,7 @@ class SubscriberPeerConnection(aiortc.RTCPeerConnection, AsyncIOEventEmitter):
         """Add a new subscriber to an existing track's MediaRelay."""
         track_data = self.track_map.get(track_id)
 
-        self._video_drain_tasks.pop(track_id, None)
-        blackhole = self._video_blackholes.pop(track_id, None)
+        blackhole, _ = self._video_blackholes.pop(track_id, (None, None))
 
         if blackhole:
             task = asyncio.create_task(blackhole.stop())

--- a/getstream/video/rtc/peer_connection.py
+++ b/getstream/video/rtc/peer_connection.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 class PeerConnectionManager:
     """Manages WebRTC peer connections for publishing and subscribing."""
 
-    def __init__(self, connection_manager, drain_video_frames: bool = False):
+    def __init__(self, connection_manager, drain_video_frames: bool = True):
         self.connection_manager = connection_manager
         self._drain_video_frames = drain_video_frames
         self.publisher_pc: Optional[PublisherPeerConnection] = None

--- a/tests/rtc/test_subscriber_drain.py
+++ b/tests/rtc/test_subscriber_drain.py
@@ -17,7 +17,6 @@ def subscriber_pc():
     pc.track_map = {}
     pc.video_frame_trackers = {}
     pc._video_blackholes = {}
-    pc._video_drain_tasks = {}
     pc._background_tasks = set()
     pc._listeners = {}
     return pc
@@ -33,14 +32,12 @@ class TestAddTrackSubscriberStopsDrain:
 
         blackhole = Mock()
         blackhole.stop = AsyncMock()
-        subscriber_pc._video_blackholes[track_id] = blackhole
-        subscriber_pc._video_drain_tasks[track_id] = Mock()
+        subscriber_pc._video_blackholes[track_id] = (blackhole, Mock())
 
         subscriber_pc.add_track_subscriber(track_id)
 
         blackhole.stop.assert_called_once()
         assert track_id not in subscriber_pc._video_blackholes
-        assert track_id not in subscriber_pc._video_drain_tasks
 
     def test_no_error_when_no_drain_exists(self, subscriber_pc):
         track_id = "user123:video:0"

--- a/tests/rtc/test_subscriber_drain.py
+++ b/tests/rtc/test_subscriber_drain.py
@@ -1,0 +1,50 @@
+"""Tests for SubscriberPeerConnection video drain behavior."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from aiortc.contrib.media import MediaRelay
+
+from getstream.video.rtc.pc import SubscriberPeerConnection
+
+
+@pytest.fixture
+def subscriber_pc():
+    """Create a SubscriberPeerConnection bypassing heavy parent inits."""
+    pc = SubscriberPeerConnection.__new__(SubscriberPeerConnection)
+    pc.connection = Mock()
+    pc._drain_video_frames = True
+    pc.track_map = {}
+    pc.video_frame_trackers = {}
+    pc._video_blackholes = {}
+    pc._video_drain_tasks = {}
+    pc._listeners = {}
+    return pc
+
+
+class TestAddTrackSubscriberStopsDrain:
+    def test_blackhole_stopped_when_subscriber_added(self, subscriber_pc):
+        track_id = "user123:video:0"
+        relay = MediaRelay()
+        original_track = Mock()
+        subscriber_pc.track_map[track_id] = (relay, original_track)
+
+        blackhole = Mock()
+        blackhole.stop = AsyncMock()
+        subscriber_pc._video_blackholes[track_id] = blackhole
+        subscriber_pc._video_drain_tasks[track_id] = Mock()
+
+        subscriber_pc.add_track_subscriber(track_id)
+
+        blackhole.stop.assert_called_once()
+        assert track_id not in subscriber_pc._video_blackholes
+        assert track_id not in subscriber_pc._video_drain_tasks
+
+    def test_no_error_when_no_drain_exists(self, subscriber_pc):
+        track_id = "user123:video:0"
+        relay = MediaRelay()
+        original_track = Mock()
+        subscriber_pc.track_map[track_id] = (relay, original_track)
+
+        result = subscriber_pc.add_track_subscriber(track_id)
+        assert result is not None

--- a/tests/rtc/test_subscriber_drain.py
+++ b/tests/rtc/test_subscriber_drain.py
@@ -18,12 +18,14 @@ def subscriber_pc():
     pc.video_frame_trackers = {}
     pc._video_blackholes = {}
     pc._video_drain_tasks = {}
+    pc._background_tasks = set()
     pc._listeners = {}
     return pc
 
 
 class TestAddTrackSubscriberStopsDrain:
-    def test_blackhole_stopped_when_subscriber_added(self, subscriber_pc):
+    @pytest.mark.asyncio
+    async def test_blackhole_stopped_when_subscriber_added(self, subscriber_pc):
         track_id = "user123:video:0"
         relay = MediaRelay()
         original_track = Mock()


### PR DESCRIPTION
## Why

When a real subscriber calls `add_track_subscriber`, the MediaBlackhole drain for that track kept running, competing with the actual consumer for frames. Additionally, drain was off by default, so tracks without explicit subscribers would accumulate unconsumed frames (aiortc issue #554).

## Changes

- Enable `drain_video_frames` by default across all layers (`ConnectionManager`, `PeerConnectionManager`, `SubscriberPeerConnection`)
- Stop and clean up blackhole drain in `add_track_subscriber` when a real subscriber arrives
- Prevent GC from collecting the blackhole stop task via `_background_tasks` set
- Add unit tests for drain cleanup behavior
- Document `drain_video_frames` lifecycle in docstring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Video-frame draining is enabled by default to prevent unconsumed-frame buildup and reduce resource usage.
  * Per-track draining now stops cleanly when a subscriber attaches, preventing lingering background tasks and improving connection stability.

* **Tests**
  * Added tests covering the video drain lifecycle and verifying drains stop when subscribers are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->