### PR TITLE
fix(rtc): drop late SFU subscriber offers when peer connection is closed

### DIFF
--- a/getstream/video/rtc/connection_manager.py
+++ b/getstream/video/rtc/connection_manager.py
@@ -198,6 +198,17 @@ class ConnectionManager(StreamAsyncIOEventEmitter):
     async def _on_subscriber_offer(self, event: events_pb2.SubscriberOffer):
         logger.info("Subscriber offer received")
 
+        # Offers can arrive after the subscriber peer connection has been
+        # torn down (slow asyncio loop under load, SFU sending a late
+        # renegotiation). `setRemoteDescription` would raise
+        # `InvalidStateError: Cannot handle offer in signaling state "closed"`
+        # and the exception propagates through the pyee error path, killing
+        # the session. Drop the offer instead — there is nothing to
+        # negotiate with a closed connection.
+        if self.subscriber_pc is None or self.subscriber_pc.signalingState == "closed":
+            logger.debug("Subscriber offer arrived after PC closed; dropping")
+            return
+
         with telemetry.start_as_current_span("rtc.on_subscriber_offer") as span:
             await self.subscriber_negotiation_lock.acquire()
 


### PR DESCRIPTION
## Why

`_on_subscriber_offer` unconditionally calls `setRemoteDescription` on `subscriber_pc`. If an offer arrives after the connection has been torn down (slow asyncio loop under load, SFU sending a late renegotiation), aiortc raises `InvalidStateError: Cannot handle offer in signaling state "closed"`. The exception then propagates through the pyee error path and kills the surrounding session.

Reproduces reliably under load: when several concurrent agent sessions run on one pod and the asyncio loop falls behind, session cleanup and a late SFU offer race. We've been observing this pattern on a production deploy that runs multiple agent sessions per pod — each unhandled error visibly drops sessions for users mid-call.

## Changes

- In `_on_subscriber_offer`, guard against a missing or closed `subscriber_pc`: drop the offer and log at debug level. Nothing to negotiate with a closed connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video connection stability by ignoring late or invalid subscriber offers when a session is no longer active.
  * Such offers are now safely dropped and logged at debug level, preventing unnecessary negotiation attempts and avoiding unexpected connection errors or terminations.
  * Reduces spurious error propagation for closed or missing subscriber sessions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-py/pull/240)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->