### PR TITLE
fix(rtc): correct `join_response` attribute access in FAST reconnect

### DIFF
--- a/getstream/video/rtc/reconnection.py
+++ b/getstream/video/rtc/reconnection.py
@@ -209,10 +209,13 @@ class ReconnectionManager:
                 self.connection_manager._connection_options.fast_reconnect = True
                 previous_ws_client = self.connection_manager.ws_client
 
-                # Use _connect_internal with existing connection info
+                # Use _connect_internal with existing connection info.
+                # `self.join_response` is already the unwrapped data payload
+                # (see ConnectionManager._connect_internal: it stores
+                # `join_response.data`), so credentials live at the top level.
                 await self.connection_manager._connect_internal(
                     region=self.connection_manager._connection_options.region,
-                    token=self.connection_manager.join_response.data.credentials.token
+                    token=self.connection_manager.join_response.credentials.token
                     if self.connection_manager.join_response
                     else None,
                     session_id=self.connection_manager.session_id,


### PR DESCRIPTION
## Why

`ConnectionManager._connect_internal` stores `join_response.data` as `self.join_response`, so credentials live at the top level. `_reconnect_fast` was reading `self.join_response.data.credentials.token`, which raises `AttributeError: 'JoinCallResponse' object has no attribute 'data'` the first time a FAST reconnect actually runs.

This codepath was never exercised in production because nothing triggered a reconnect on signaling-WS loss. With #241 finally driving into `ReconnectionManager`, this latent bug surfaces and would crash the first FAST attempt — so it needs to land before (or together with) that PR.

## Changes

- Drop the spurious `.data` hop in `ReconnectionManager._reconnect_fast` (`getstream/video/rtc/reconnection.py`).

Related: #241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reconnection flow to retrieve authentication tokens from the correct location in the response, ensuring more reliable connection re-establishment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-py/pull/242)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->