### PR TITLE
Fix false-positive reconnect attempts in signaling websocket

### DIFF
--- a/getstream/video/rtc/reconnection.py
+++ b/getstream/video/rtc/reconnection.py
@@ -218,6 +218,9 @@ class ReconnectionManager:
                     token=self.connection_manager.join_response.credentials.token
                     if self.connection_manager.join_response
                     else None,
+                    ws_url=self.connection_manager.join_response.credentials.server.ws_endpoint
+                    if self.connection_manager.join_response
+                    else None,
                     session_id=self.connection_manager.session_id,
                 )
 

--- a/getstream/video/rtc/signaling.py
+++ b/getstream/video/rtc/signaling.py
@@ -68,6 +68,10 @@ class WebSocketClient(StreamAsyncIOEventEmitter):
         self.running = False
         self.closed = False
         self._connection_lost_sent = False
+        # Set when a `call_ended` SFU event arrives. Read by `_on_close` to
+        # suppress `connection_lost`, since the close frame that follows carries
+        # no distinguishing status code or reason.
+        self._call_ended = False
 
         # For ping/health check mechanism
         self.ping_thread = None
@@ -168,6 +172,9 @@ class WebSocketClient(StreamAsyncIOEventEmitter):
         event_type = event.WhichOneof("event_payload")
         logger.debug(f"WebSocket message received {event_type}")
 
+        if event_type and event_type == "call_ended":
+            self._call_ended = True
+
         if event.HasField("health_check_response"):
             logger.debug("received health check response")
             self.last_health_check_time = time.time()
@@ -199,29 +206,30 @@ class WebSocketClient(StreamAsyncIOEventEmitter):
 
     def _on_error(self, ws, error):
         """Handle WebSocket error."""
-        if (
+        is_close_frame = (
             isinstance(error, websocket.ABNF)
             and error.opcode == websocket.ABNF.OPCODE_CLOSE
-        ):
-            # For some reason, websockets lib propagates closing frame as an error.
-            # Simply log a debug here if that happens.
-            logger.debug(f"WebSocket closed by server: {error}")
+        )
+        if is_close_frame or not self.running:
+            # Close-frame-as-error or post-disconnect teardown noise.
+            logger.debug(f"WebSocket error after disconnect: {error}")
         else:
             logger.error(f"WebSocket error: {error}")
 
         if not self.first_message_event.is_set():
-            # Create an error event
+            # Mid-handshake failure: unblock `connect()` with a synthetic
+            # error event instead of leaving it parked on `first_message_event`.
             error_event = events_pb2.SfuEvent()
             error_event.error.error.message = str(error)
             self.first_message = error_event
             self.first_message_event.set()
-        elif not self.closed:
+        elif not self.closed and not is_close_frame:
             self._notify_connection_lost(f"error: {error}")
 
     def _on_close(self, ws, close_status_code, close_msg):
         """Handle WebSocket close event."""
         logger.debug(f"WebSocket connection closed: {close_status_code} {close_msg}")
-        was_unexpected = not self.closed
+        was_unexpected = not self.closed and not self._call_ended
         self.running = False
         if was_unexpected:
             self._notify_connection_lost(
@@ -248,7 +256,7 @@ class WebSocketClient(StreamAsyncIOEventEmitter):
             logger.exception("Failed to schedule connection_lost emit")
 
     def _claim_connection_lost(self) -> bool:
-        """Return True iff this is the first connection-lost notification."""
+        """Return True if this is the first connection-lost notification."""
         if self._connection_lost_sent:
             return False
         self._connection_lost_sent = True

--- a/tests/test_signaling.py
+++ b/tests/test_signaling.py
@@ -3,6 +3,8 @@ import pytest
 import threading
 from unittest.mock import patch
 
+import websocket
+
 from getstream.video.rtc.signaling import WebSocketClient, SignalingError
 from getstream.video.rtc.pb.stream.video.sfu.event import events_pb2
 from getstream.video.rtc.pb.stream.video.sfu.models import models_pb2
@@ -398,6 +400,67 @@ class TestWebSocketClient:
         assert len(received) == 1, (
             f"expected exactly one connection_lost event for the chain, got {received}"
         )
+
+        client.close()
+
+    @pytest.mark.asyncio
+    async def test_call_ended_suppresses_connection_lost(self, join_request):
+        """A `call_ended` event before close suppresses `connection_lost`.
+
+        The SFU sends `call_ended`, then closes the WS with no distinguishing
+        status (close code and reason are both None). Without an application-
+        level intent signal this would be indistinguishable from a TCP drop
+        and trip a spurious reconnect.
+        """
+        client = WebSocketClient(
+            "wss://test.url", join_request, asyncio.get_running_loop()
+        )
+        received: list[str] = []
+
+        async def on_lost(reason):
+            received.append(reason)
+
+        client.on_event("connection_lost", on_lost)
+
+        call_ended_event = events_pb2.SfuEvent()
+        call_ended_event.call_ended.reason = models_pb2.CALL_ENDED_REASON_ENDED
+
+        client._on_message(None, call_ended_event.SerializeToString())
+        client._on_close(None, None, None)
+
+        await asyncio.sleep(0.05)
+
+        assert received == []
+
+    @pytest.mark.asyncio
+    async def test_close_frame_during_handshake_raises(
+        self, join_request, mock_websocket
+    ):
+        """An ABNF close frame mid-handshake unblocks `connect()` with an error.
+
+        websocket-client surfaces a server-side close as both an error (an
+        `ABNF` close frame in `_on_error`) and an `_on_close` callback. If
+        this happens before the first SFU event, neither callback sets
+        `first_message_event` by default, so `connect()` would hang on the
+        executor wait. The synthetic error path in `_on_error` is what
+        unblocks it.
+        """
+        client = WebSocketClient(
+            "wss://test.url", join_request, asyncio.get_running_loop()
+        )
+
+        connect_task = asyncio.create_task(client.connect())
+        await asyncio.sleep(0.1)
+
+        # Server closed the socket before sending any SFU event.
+        close_frame = websocket.ABNF()
+        close_frame.opcode = websocket.ABNF.OPCODE_CLOSE
+
+        on_error_callback = mock_websocket.call_args[1]["on_error"]
+        on_error_callback(mock_websocket.return_value, close_frame)
+
+        with pytest.raises(SignalingError, match="Connection failed"):
+            await connect_task
 
         client.close()
 


### PR DESCRIPTION
## Why?
1. Signaling websocket handler was trying to reconnect on normal WS closure triggered by the `"call_ended"` SFU event.  
That is fixed. It now checks if `"call_ended"` was received before trying to reconnect.

2. When trying to reconnect, it was failing because the websocket url was not passed properly.  
That is fixed too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection loss notification handling after call termination, reducing spurious error messages.
  * Enhanced error handling for websocket disconnections and interruptions during connection handshake.
  * Better suppression of noise from post-disconnect cleanup operations.

* **Tests**
  * Added test coverage for call-ended event handling and websocket interruptions during handshake scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-py/pull/244)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->