### PR TITLE
[CHA-2963] Adopt unified release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ on:
 
 concurrency:
   group: release-${{ github.event.pull_request.base.ref || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,60 +1,219 @@
-name: Integration (pre-release / release)
+name: Release
+
 on:
-  release:
-    types: [published] # Run after a Github publish
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type for manual release'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      use_current_version:
+        description: 'Skip version bump and publish the version already set in pyproject.toml'
+        required: false
+        default: false
+        type: boolean
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+concurrency:
+  group: release-${{ github.event.pull_request.base.ref || github.ref_name }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
-  id-token: write       # REQUIRED for PyPI Trusted Publishing (OIDC)
 
 jobs:
-  integration:
+  prepare:
+    name: Prepare release
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.release_meta_final.outputs.should_release }}
+      bump: ${{ steps.release_meta_final.outputs.bump }}
+      previous_version: ${{ steps.release_meta_final.outputs.previous_version }}
+      version: ${{ steps.release_meta_final.outputs.version }}
+      tag: ${{ steps.release_meta_final.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+
+      - name: Skip when PR is already released
+        id: already_released
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            if git log --oneline --grep="(pr #${{ github.event.pull_request.number }})" -n 1 | grep -q "chore(release):"; then
+              echo "value=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "value=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Determine version bump (from PR metadata)
+        id: release_meta
+        if: github.event_name == 'pull_request' && steps.already_released.outputs.value != 'true'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          PR_BODY_FILE=$(mktemp)
+          printf '%s' "$PR_BODY" > "$PR_BODY_FILE"
+          python3 scripts/release/bump_version.py \
+            --title "$PR_TITLE" \
+            --body-file "$PR_BODY_FILE" \
+            --output "$GITHUB_OUTPUT"
+
+      - name: Determine version bump (manual)
+        id: release_meta_manual
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          python3 scripts/release/bump_version.py \
+            --manual-bump "${{ github.event.inputs.version_bump }}" \
+            --use-current-version "${{ github.event.inputs.use_current_version }}" \
+            --output "$GITHUB_OUTPUT"
+
+      - name: Consolidate release metadata
+        id: release_meta_final
+        run: |
+          if [ "${{ steps.already_released.outputs.value }}" = "true" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "bump=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should_release=${{ steps.release_meta_manual.outputs.should_release }}" >> "$GITHUB_OUTPUT"
+            echo "bump=${{ steps.release_meta_manual.outputs.bump }}" >> "$GITHUB_OUTPUT"
+            echo "previous_version=${{ steps.release_meta_manual.outputs.previous_version }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ steps.release_meta_manual.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ steps.release_meta_manual.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=${{ steps.release_meta.outputs.should_release }}" >> "$GITHUB_OUTPUT"
+            echo "bump=${{ steps.release_meta.outputs.bump }}" >> "$GITHUB_OUTPUT"
+            echo "previous_version=${{ steps.release_meta.outputs.previous_version }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ steps.release_meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ steps.release_meta.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  test-unit:
+    name: Test (unit)
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
+    uses: ./.github/workflows/run_tests.yml
+    with:
+      marker: 'not integration'
+    secrets: inherit
+
+  test-integration:
+    name: Test (integration)
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
     uses: ./.github/workflows/run_tests.yml
     with:
       marker: 'integration'
     secrets: inherit
 
-  build:
-    name: Build & Publish SDK
+  release:
+    name: 🚀 Release
+    needs: [prepare, test-unit, test-integration]
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     environment: pypi
-    outputs:
-      version: ${{ steps.get_version.outputs.version }}
+    permissions:
+      contents: write
+      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+
       - uses: ./.github/actions/python-uv-setup
 
-      - name: Clean dist directory
+      - name: Apply version bump
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          rm -rf dist
+          python3 - <<'PY'
+          import os, re
+          from pathlib import Path
+          version = os.environ['VERSION']
+          path = Path('pyproject.toml')
+          text = path.read_text(encoding='utf-8')
+          pattern = re.compile(r'^version\s*=\s*"\d+\.\d+\.\d+"\s*$', re.MULTILINE)
+          new_text, count = pattern.subn(f'version = "{version}"', text, count=1)
+          if count == 0:
+              raise SystemExit('Could not update version line in pyproject.toml')
+          path.write_text(new_text, encoding='utf-8')
+          PY
+
+      - name: Commit version bump
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            git commit -m "chore(release): v${VERSION} (manual)"
+            git push origin "HEAD:${{ github.ref_name }}"
+          else
+            git commit -m "chore(release): v${VERSION} (pr #${{ github.event.pull_request.number }})"
+            git push origin "HEAD:${{ github.event.pull_request.base.ref }}"
+          fi
+
+      - name: Create release tag
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists; skipping tag creation."
+            exit 0
+          fi
+          git tag "${TAG}"
+          git push origin "${TAG}"
+
+      - name: Clean dist directory
+        run: rm -rf dist
 
       - name: Build distributions
-        run: |
-          uv build
-
-      - name: Extract package version
-        id: get_version
-        run: |
-          FILE=$(ls dist/getstream-*.tar.gz | head -1)
-          VERSION=$(basename "$FILE" .tar.gz | sed 's/^getstream-//')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        run: uv build
 
       - name: Publish to PyPI (Trusted Publishing)
         run: uv publish
 
-  test-index:
-    name: Verify PIP install works
-    needs: build
-    runs-on: ubuntu-latest
-    env:
-      UV_NO_SOURCES: "1"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - uses: ./.github/actions/python-uv-setup
+      - name: Create release on GitHub
+        uses: ncipollo/release-action@v1
         with:
-          sync-flags: "--all-extras --dev"
-      - name: Install from PyPI using uv
+          tag: ${{ needs.prepare.outputs.tag }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          skipIfReleaseExists: true
+          body: |
+            Release v${{ needs.prepare.outputs.version }}
+
+            - Bump type: `${{ needs.prepare.outputs.bump }}`
+            - Previous: `${{ needs.prepare.outputs.previous_version }}`
+            - Next: `${{ needs.prepare.outputs.version }}`
+            - Trigger: `${{ github.event_name }}`
+
+            Install with: `pip install getstream==${{ needs.prepare.outputs.version }}`
+
+      - name: Verify pip install
+        env:
+          UV_NO_SOURCES: "1"
         run: |
-          uv pip install getstream==${{ needs.build.outputs.version }}
+          uv pip install "getstream==${{ needs.prepare.outputs.version }}" || \
+            echo "WARNING: pip install verification failed (PyPI index may need a moment to propagate)"

--- a/README.md
+++ b/README.md
@@ -230,6 +230,23 @@ uv run pytest -v -s
 uv run pytest tests/test_video.py::test_specific_function -v
 ```
 
+## Releases
+
+Releases use two paths:
+
+- **Default**: automatic release when a PR is merged to `main`. The PR title (and body) drives the semver bump.
+- **Fallback**: manual release via the `Release` workflow's `workflow_dispatch` (admin use). Select a `version_bump` (`patch`/`minor`/`major`). `use_current_version=true` skips the bump and publishes whatever is already in `pyproject.toml`.
+
+Automatic semver bump rules:
+
+- `feat:` -> minor
+- `fix:` (or `bug:`) -> patch
+- `feat!:`, `<type>(scope)!:`, or `BREAKING CHANGE` in the PR body/title -> major
+
+PRs with any other prefix do not trigger a release.
+
+The release pipeline runs lint, type-check, and the full test matrix (unit + integration, across all supported Python versions) on the merged commit before publishing to PyPI via Trusted Publishing (OIDC). Each step in the publish job is idempotent: a failed run can be re-dispatched from the Actions UI.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "getstream"
-dynamic = [ "version" ]
+version = "3.3.4"
 description = "GetStream Python SDK - Build scalable activity feeds, chat, and video calling applications"
 authors = [
     { name = "sachaarbonel", email = "sacha.arbonel@hotmail.fr" },
@@ -100,12 +100,8 @@ members = [
  ]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs", "setuptools-scm"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.version]
-source = "vcs"
-raw-options = {  search_parent_directories = true, fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["getstream"]

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -107,9 +107,7 @@ def read_pyproject_version(path: Path) -> str:
 
 def update_pyproject_version(path: Path, version: str) -> None:
     text = path.read_text(encoding="utf-8")
-    new_text, count = VERSION_LINE_PATTERN.subn(
-        f'version = "{version}"', text, count=1
-    )
+    new_text, count = VERSION_LINE_PATTERN.subn(f'version = "{version}"', text, count=1)
     if count == 0:
         raise RuntimeError(
             'Could not update version line in pyproject.toml (expected `version = "X.Y.Z"`)'

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Compute the next release version from PR title/body or workflow_dispatch input.
+
+Usage:
+  scripts/release/bump_version.py \
+      --title "feat: add x" --body-file "$PR_BODY_FILE" \
+      --output "$GITHUB_OUTPUT"
+
+  scripts/release/bump_version.py \
+      --manual-bump patch \
+      --output "$GITHUB_OUTPUT"
+
+  scripts/release/bump_version.py \
+      --manual-bump patch --use-current-version true \
+      --output "$GITHUB_OUTPUT"
+
+Outputs (written to --output or stdout) follow the convention shared with the
+getstream-php / getstream-ruby / getstream-net / getstream-go / stream-sdk-java
+bump scripts:
+
+  should_release=true|false
+  bump=major|minor|patch|none
+  previous_version=X.Y.Z
+  version=X.Y.Z
+  tag=vX.Y.Z
+
+Side effect: in auto and manual-with-bump modes, updates the `version` field in
+the top-level [project] table of pyproject.toml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PYPROJECT_PATH = Path("pyproject.toml")
+SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+VERSION_LINE_PATTERN = re.compile(
+    r'^version\s*=\s*"(\d+\.\d+\.\d+)"\s*$',
+    re.MULTILINE,
+)
+
+
+def run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def find_latest_semver_tag() -> str:
+    raw = run(["git", "tag", "--list"])
+    if not raw:
+        return "0.0.0"
+    versions: list[tuple[int, int, int]] = []
+    for line in raw.splitlines():
+        candidate = line.strip().lstrip("v")
+        if SEMVER_PATTERN.match(candidate):
+            major, minor, patch = candidate.split(".")
+            versions.append((int(major), int(minor), int(patch)))
+    if not versions:
+        return "0.0.0"
+    versions.sort()
+    return "{}.{}.{}".format(*versions[-1])
+
+
+def determine_bump_type(title: str, body: str) -> str:
+    title = title.strip()
+    body = body.strip()
+    breaking_re = re.compile(r"BREAKING[ -]CHANGES?", re.IGNORECASE)
+    if breaking_re.search(title) or breaking_re.search(body):
+        return "major"
+    match = re.match(r"^([a-zA-Z]+)(\([^)]+\))?(!)?:", title)
+    if not match:
+        return "none"
+    if match.group(3) == "!":
+        return "major"
+    type_ = match.group(1).lower()
+    if type_ == "feat":
+        return "minor"
+    if type_ in {"fix", "bug"}:
+        return "patch"
+    return "none"
+
+
+def increment_version(current: str, bump: str) -> str:
+    major, minor, patch = (int(x) for x in current.split("."))
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    if bump == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    return current
+
+
+def read_pyproject_version(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = VERSION_LINE_PATTERN.search(text)
+    if not match:
+        raise RuntimeError(
+            'Could not find a static `version = "X.Y.Z"` line in pyproject.toml'
+        )
+    return match.group(1)
+
+
+def update_pyproject_version(path: Path, version: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    new_text, count = VERSION_LINE_PATTERN.subn(
+        f'version = "{version}"', text, count=1
+    )
+    if count == 0:
+        raise RuntimeError(
+            'Could not update version line in pyproject.toml (expected `version = "X.Y.Z"`)'
+        )
+    path.write_text(new_text, encoding="utf-8")
+
+
+def parse_bool(value: str) -> bool:
+    return value.strip().lower() == "true"
+
+
+def resolve_body(args: argparse.Namespace) -> str:
+    if args.body_file:
+        return Path(args.body_file).read_text(encoding="utf-8")
+    return args.body or ""
+
+
+def write_outputs(output_path: str, entries: dict[str, str]) -> None:
+    if not output_path:
+        for key, value in entries.items():
+            print(f"{key}={value}")
+        return
+    with open(output_path, "a", encoding="utf-8") as fh:
+        for key, value in entries.items():
+            fh.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--title", default="")
+    parser.add_argument("--body", default="")
+    parser.add_argument("--body-file", dest="body_file", default="")
+    parser.add_argument("--output", default="")
+    parser.add_argument("--manual-bump", dest="manual_bump", default="")
+    parser.add_argument(
+        "--use-current-version",
+        dest="use_current_version",
+        default="false",
+    )
+    args = parser.parse_args()
+
+    manual = args.manual_bump.strip().lower()
+    use_current = parse_bool(args.use_current_version)
+
+    if manual:
+        if manual not in {"major", "minor", "patch"}:
+            print("manual-bump must be one of: major, minor, patch", file=sys.stderr)
+            return 1
+        previous = find_latest_semver_tag()
+        if use_current:
+            next_version = read_pyproject_version(PYPROJECT_PATH)
+        else:
+            next_version = increment_version(previous, manual)
+            update_pyproject_version(PYPROJECT_PATH, next_version)
+        write_outputs(
+            args.output,
+            {
+                "should_release": "true",
+                "bump": manual,
+                "previous_version": previous,
+                "version": next_version,
+                "tag": f"v{next_version}",
+            },
+        )
+        return 0
+
+    body = resolve_body(args)
+    bump = determine_bump_type(args.title, body)
+    if bump == "none":
+        write_outputs(
+            args.output,
+            {
+                "should_release": "false",
+                "bump": "none",
+            },
+        )
+        return 0
+
+    previous = find_latest_semver_tag()
+    next_version = increment_version(previous, bump)
+    update_pyproject_version(PYPROJECT_PATH, next_version)
+
+    write_outputs(
+        args.output,
+        {
+            "should_release": "true",
+            "bump": bump,
+            "previous_version": previous,
+            "version": next_version,
+            "tag": f"v{next_version}",
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -895,6 +895,7 @@ wheels = [
 
 [[package]]
 name = "getstream"
+version = "3.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "dataclasses-json" },
@@ -995,7 +996,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'webrtc'", specifier = ">=15.0.1" },
     { name = "websockets", marker = "extra == 'webrtc'", specifier = ">=15.0.1,<16" },
 ]
-provides-extras = ["openai-realtime", "telemetry", "webrtc"]
+provides-extras = ["openai-realtime", "webrtc", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Aligns stream-py's release flow with the cross-SDK pattern agreed for CHA-2963. A single `release.yml` supports automatic releases on PR merge and manual releases via `workflow_dispatch`.

## Changes

- **`release.yml`** — full rewrite. PR-merge (PR-title-driven) + `workflow_dispatch` (`version_bump` choice + `use_current_version`). Jobs: `prepare` → `test-unit` + `test-integration` (both via the existing `run_tests.yml` workflow_call) → `release`. Release job re-applies version, commits, tags, `uv build`, `uv publish` (OIDC), creates GH Release. Idempotent retries.
- **`pyproject.toml`** — `dynamic = ["version"]` → static `version = "3.3.4"`. `[build-system] requires` trimmed to `["hatchling"]`. `[tool.hatch.version]` block removed. `hatch-vcs` left in dev deps to keep `uv.lock` valid; cleanup + re-lock is a follow-up.
- **`scripts/release/bump_version.py`** — new. Same CLI shape and bump rules as the PHP/Ruby/.NET/Go/Java equivalents: `feat:` → minor, `fix:`/`bug:` → patch, `feat!:` or `BREAKING CHANGE` → major. Locally smoke-tested across 12 title cases + 5 end-to-end scenarios.
- **`README.md`** — added `## Releases` section.

## Deliberate omissions

Per the agreed cross-SDK decisions: no pre-release path, no CHANGELOG generation in the workflow, manual-dispatch uses a `version_bump` dropdown (not a free-form version string).

## Behavior change

Old `release.yml` triggered on `release: published` (manual GH Release creation). After this PR, manual GH Release creation no longer publishes — releases are cut via PR merge or `workflow_dispatch`.

This PR's title does not match the auto-release prefix convention, so merging it will not trigger a release. First release on the new flow should be a manual `workflow_dispatch` with `version_bump=patch` to validate end-to-end.

## Test plan

- [ ] Manual `workflow_dispatch` with `version_bump=patch` → patch release cuts cleanly
- [ ] Manual `workflow_dispatch` with `use_current_version=true` → publishes the version in `pyproject.toml` without bumping
- [ ] `feat:`-prefixed PR merge → minor release auto-cuts
- [ ] `fix:`-prefixed PR merge → patch release auto-cuts
- [ ] `chore:`-prefixed PR merge → no release
- [ ] Introduce a failing test on a release PR → publish gated, no PyPI push / tag / GH Release
- [ ] Confirm PyPI OIDC trusted publishing still works
- [ ] Re-run a failed `release` job from Actions UI → no duplicate tag / release / upload


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release pipeline with automated version management and improved publishing workflow
  * Updated documentation with release process details including semantic versioning guidelines and publishing mechanism
  * Simplified build system configuration for improved maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-py/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->