### PR TITLE
Fix/release concurrency group between unit and integration

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ on:
         type: string
     secrets: { }
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.marker }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Why

`release.yml` calls the reusable `run_tests.yml` twice in the same run — once for `marker: 'not integration'`, once for `marker: 'integration'`. Both call sites computed the same concurrency group key (`${{ github.workflow }}-${{ github.ref }}` resolves identically when the caller workflow and branch are the same), so whichever test job started second cancelled the first via `cancel-in-progress: true`.

That left one of the two test jobs in `cancelled`, which meant the `release` job's `needs: [prepare, test-unit, test-integration]` could not be satisfied and publication was skipped. The v3.4.0 attempt at https://github.com/GetStream/stream-py/actions/runs/26415677026 is an example — all `Test (integration)` jobs cancelled the moment `Test (unit)` started.

Including `inputs.marker` in the group key gives each call its own concurrency lane, so unit and integration runs no longer cancel each other.

The PR title intentionally does not use a conventional-commits prefix (`fix:`/`feat:`), so the auto-release path won't try to bump on merge — the release should be retriggered manually via `workflow_dispatch` after this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test workflow concurrency handling to better manage concurrent test executions with different input parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-py/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->