### PR TITLE
Fix/treat pytest exit 5 (no tests collected) as success

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,13 @@ TY_EXCLUDES := \
 
 ## Run non-video tests (chat, feeds, moderation, etc.)
 test:
-	uv run pytest -m "$(MARKER)" tests/ getstream/ $(VIDEO_IGNORE) $(MANUAL_IGNORE)
+	@uv run pytest -m "$(MARKER)" tests/ getstream/ $(VIDEO_IGNORE) $(MANUAL_IGNORE); \
+	ec=$$?; if [ $$ec -eq 5 ]; then echo "No tests matched marker '$(MARKER)' — treating as success."; exit 0; else exit $$ec; fi
 
 ## Run video/WebRTC tests only
 test-video:
-	uv run pytest -m "$(MARKER)" $(VIDEO_PATHS)
+	@uv run pytest -m "$(MARKER)" $(VIDEO_PATHS); \
+	ec=$$?; if [ $$ec -eq 5 ]; then echo "No tests matched marker '$(MARKER)' — treating as success."; exit 0; else exit $$ec; fi
 
 ## Run all tests (non-video + video), excluding manual tests
 test-all:


### PR DESCRIPTION
## Why

The release pipeline runs `make test MARKER="integration"` against the non-video test paths. There are currently no `@pytest.mark.integration` tests in those paths, so pytest collects 579 items and deselects all 579, exiting with code 5 ("no tests collected"). `make` treats that as a failure, so every `Test (integration) / Non-video tests (3.x)` matrix cell reports failure and the `release` job's `needs:` cannot be satisfied — that's what blocked the v3.4.0 publication attempt at https://github.com/GetStream/stream-py/actions/runs/26416959683.

Wrap the `test` and `test-video` recipes so exit code 5 is converted to 0 (with a log line), while every other non-zero code still propagates. Symmetric across both recipes since either group can have an empty marker selection in the future.

The PR title intentionally does not use a conventional-commits prefix (`fix:`/`feat:`), so the auto-release path won't try to bump on merge — `workflow_dispatch` should be re-run manually after this lands.