### PR TITLE
feat: [CHA-2958] error hierarchy + wait_for_task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Standardized error hierarchy ([CHA-2958](https://linear.app/stream/issue/CHA-2958)).
+  New exception classes importable from `getstream` (also re-exported from
+  `getstream.exceptions`):
+    - `StreamException`: abstract base for every SDK error.
+    - `StreamApiException`: any HTTP 4xx/5xx response. Carries `status_code`,
+      `code`, `message`, `exception_fields`, `unrecoverable`,
+      `raw_response_body`, `more_info`, `details`. The `unrecoverable` flag
+      from `APIError` is now surfaced (was previously dropped on most paths).
+    - `StreamRateLimitException`: subclass of `StreamApiException` raised on
+      HTTP 429. Adds `retry_after: datetime.timedelta | None`, parsed from
+      `Retry-After` per RFC 7231 (integer seconds or HTTP-date). Missing or
+      unparseable headers map to `None`; past HTTP-dates clamp to `0`.
+    - `StreamTransportException`: raised when a network-layer failure (no
+      HTTP response received) propagates out of `httpx` — connection reset,
+      timeout, TLS handshake failure, DNS failure. Carries `error_type`
+      enum (`connection_reset` / `timeout` / `dns_failure` /
+      `tls_handshake_failed` / `unknown`). The original `httpx` exception
+      is preserved as `__cause__`.
+    - `StreamTaskException`: raised by `wait_for_task` when the polled task
+      ends in `status='failed'`. Carries `task_id`, `error_type`,
+      `description`, `stack_trace`, `version`.
+- `Stream.wait_for_task(task_id, *, poll_interval=1.0, timeout=60.0)` and
+  the matching async coroutine on `AsyncStream`. Polls `get_task` until the
+  task reaches a terminal state. On `completed` returns the
+  `StreamResponse[GetTaskResponse]`; on `failed` raises
+  `StreamTaskException` populated from `ErrorResult`; on timeout raises
+  `StreamTransportException(error_type='timeout')`.
+
 - Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
   Four new kwargs on `Stream(...)` and `AsyncStream(...)`:
     - `max_conns_per_host: int`: default `5`
@@ -45,10 +73,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- HTTP request errors raised by `httpx` (the `httpx.RequestError` family —
+  `ConnectError`, `ReadTimeout`, etc.) are now wrapped at the SDK boundary
+  in `StreamTransportException` so callers handle one Stream error category
+  instead of catching `httpx.RequestError` separately. The original `httpx`
+  exception is preserved via `__cause__` (CHA-2958).
 - **Default `request_timeout` is now `30.0` seconds (was `6.0`).** Aligns stream-py with the cross-SDK contract in CHA-2956. Existing callers using `timeout=` are unaffected; `timeout` is kept as an alias for `request_timeout`. Callers relying on the 6s ceiling for fail-fast behavior should pass `request_timeout=6.0` (or `timeout=6.0`) explicitly.
 - Default HTTP transport now caps connections per host at `5` and closes idle sockets after `55.0s`. Previous default was httpx's `100` max-connections with `5.0s` keep-alive expiry.
 - No breaking changes. All existing webhook helpers (`verify_webhook_signature`,
   `parse_webhook_event`, `get_event_type`, event type constants) are preserved.
+
+### Deprecated
+
+- `getstream.base.StreamAPIException` (capital `API`) is now an alias for
+  `getstream.exceptions.StreamApiException` (lowercase `Api`). Importing the
+  old name emits `DeprecationWarning`; existing `isinstance` / `except` /
+  `pytest.raises` checks continue to work because the alias resolves to the
+  same class. The legacy spelling will be removed one minor cycle after this
+  release (CHA-2958 §10).
 
 ### Notes
 

--- a/getstream/__init__.py
+++ b/getstream/__init__.py
@@ -1,2 +1,9 @@
+from getstream.exceptions import (  # noqa: F401
+    StreamApiException,
+    StreamException,
+    StreamRateLimitException,
+    StreamTaskException,
+    StreamTransportException,
+)
 from getstream.stream import Stream  # noqa: F401
 from getstream.stream import AsyncStream  # noqa: F401

--- a/getstream/base.py
+++ b/getstream/base.py
@@ -4,11 +4,15 @@ import mimetypes
 import os
 import time
 import uuid
+import warnings
 import asyncio
 from typing import Any, Dict, List, Optional, Tuple, Type, cast, get_origin
 
-from getstream.models import APIError
-from getstream.rate_limit import extract_rate_limit
+from getstream.exceptions import (
+    StreamApiException,
+    build_api_exception,
+    wrap_transport_error,
+)
 from getstream.stream_response import StreamResponse
 from getstream.generic import T
 import httpx
@@ -102,9 +106,7 @@ class ResponseParserMixin:
         self, response: httpx.Response, data_type: Type[T]
     ) -> StreamResponse[T]:
         if response.status_code >= 399:
-            raise StreamAPIException(
-                response=response,
-            )
+            raise build_api_exception(response)
 
         try:
             parsed_result = json.loads(response.text) if response.text else {}
@@ -118,10 +120,8 @@ class ResponseParserMixin:
             else:
                 data = cast(T, parsed_result)
 
-        except (ValueError, AttributeError):
-            raise StreamAPIException(
-                response=response,
-            )
+        except (ValueError, AttributeError) as err:
+            raise StreamApiException(response=response) from err
 
         return StreamResponse(response, data)
 
@@ -291,9 +291,15 @@ class BaseClient(TelemetryEndpointMixin, BaseConfig, ResponseParserMixin, ABC):
         ) as span:
             call_kwargs = dict(kwargs)
             call_kwargs.pop("path_params", None)
-            response = getattr(self.client, method.lower())(
-                url_path, params=query_params, *args, **call_kwargs
-            )
+            try:
+                response = getattr(self.client, method.lower())(
+                    url_path, params=query_params, *args, **call_kwargs
+                )
+            except httpx.RequestError as err:
+                # Spec §6.1/§6.4: wrap transport-layer failures at the HTTP-client
+                # boundary; preserve the original via ``raise ... from err`` so
+                # ``__cause__`` exposes the underlying ``httpx`` exception.
+                raise wrap_transport_error(err) from err
             duration = parse_duration_from_body(response.content)
             if duration:
                 span.set_attribute("http.server.duration", duration)
@@ -604,9 +610,14 @@ class AsyncBaseClient(TelemetryEndpointMixin, BaseConfig, ResponseParserMixin, A
                 call_kwargs["headers"] = call_kwargs.get("headers", {})
                 call_kwargs["headers"]["Content-Type"] = "application/json"
 
-            response = await getattr(self.client, method.lower())(
-                url_path, params=query_params, *args, **call_kwargs
-            )
+            try:
+                response = await getattr(self.client, method.lower())(
+                    url_path, params=query_params, *args, **call_kwargs
+                )
+            except httpx.RequestError as err:
+                # Spec §6.1/§6.4: wrap transport-layer failures at the HTTP-client
+                # boundary; preserve the original via ``raise ... from err``.
+                raise wrap_transport_error(err) from err
             duration = parse_duration_from_body(response.content)
             if duration:
                 span.set_attribute("http.server.duration", duration)
@@ -721,54 +732,25 @@ class AsyncBaseClient(TelemetryEndpointMixin, BaseConfig, ResponseParserMixin, A
         )
 
 
-class StreamAPIException(Exception):
+def __getattr__(name: str):
+    """Lazy back-compat alias: ``from getstream.base import StreamAPIException``
+    keeps working but emits ``DeprecationWarning`` per CHA-2958 §10.
+
+    The canonical class is :class:`getstream.exceptions.StreamApiException`
+    (lowercase ``Api``); the old capitalised alias will be removed one minor
+    cycle after rollout.
     """
-    A custom exception for handling errors from a Stream API response.
-
-    This exception is raised when an API call encounters an issue, providing
-    detailed information from the HTTP response. It attempts to parse the response
-    content into a structured API error. If the response content is not JSON or
-    lacks the expected structure, it will simply report the HTTP status code.
-
-    Attributes:
-        api_error (Optional[APIError]): An optional APIError object that is
-            populated if the response content contains structured error information.
-        rate_limit_info (RateLimitInfo): Information about the API's rate limiting
-            controls extracted from the response headers.
-        http_response (httpx.Response): The full HTTP response object from httpx.
-        status_code (int): The HTTP status code from the response.
-
-    Args:
-        response (httpx.Response): The HTTP response received from the Stream API.
-
-    Raises:
-        ValueError: If the response content cannot be parsed into JSON, indicating
-            that the server's response was not in the expected format.
-    """
-
-    def __init__(self, response: httpx.Response) -> None:
-        self.api_error: Optional[APIError] = None
-        self.rate_limit_info = extract_rate_limit(response)
-        self.http_response = response
-        self.status_code = response.status_code
-
-        try:
-            parsed_response: Dict = json.loads(response.content)
-            self.api_error = APIError.from_dict(parsed_response)
-        except ValueError:
-            pass
-
-    def __str__(self) -> str:
-        if self.api_error:
-            return f'Stream error code {self.api_error.code}: {self.api_error.message}"'
-        body_preview = ""
-        try:
-            text = self.http_response.text[:200] if self.http_response.text else ""
-            if text:
-                body_preview = f" body: {text}"
-        except Exception:
-            pass
-        return f"Stream error HTTP code: {self.status_code}{body_preview}"
+    if name == "StreamAPIException":
+        warnings.warn(
+            "getstream.base.StreamAPIException is deprecated; import "
+            "StreamApiException from getstream (or getstream.exceptions) "
+            "instead. The legacy alias will be removed one minor cycle after "
+            "this release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return StreamApiException
+    raise AttributeError(f"module 'getstream.base' has no attribute {name!r}")
 
 
 def parse_duration_from_body(body: bytes) -> Optional[str]:

--- a/getstream/base.py
+++ b/getstream/base.py
@@ -296,9 +296,6 @@ class BaseClient(TelemetryEndpointMixin, BaseConfig, ResponseParserMixin, ABC):
                     url_path, params=query_params, *args, **call_kwargs
                 )
             except httpx.RequestError as err:
-                # Spec §6.1/§6.4: wrap transport-layer failures at the HTTP-client
-                # boundary; preserve the original via ``raise ... from err`` so
-                # ``__cause__`` exposes the underlying ``httpx`` exception.
                 raise wrap_transport_error(err) from err
             duration = parse_duration_from_body(response.content)
             if duration:
@@ -615,8 +612,6 @@ class AsyncBaseClient(TelemetryEndpointMixin, BaseConfig, ResponseParserMixin, A
                     url_path, params=query_params, *args, **call_kwargs
                 )
             except httpx.RequestError as err:
-                # Spec §6.1/§6.4: wrap transport-layer failures at the HTTP-client
-                # boundary; preserve the original via ``raise ... from err``.
                 raise wrap_transport_error(err) from err
             duration = parse_duration_from_body(response.content)
             if duration:
@@ -733,13 +728,7 @@ class AsyncBaseClient(TelemetryEndpointMixin, BaseConfig, ResponseParserMixin, A
 
 
 def __getattr__(name: str):
-    """Lazy back-compat alias: ``from getstream.base import StreamAPIException``
-    keeps working but emits ``DeprecationWarning`` per CHA-2958 §10.
-
-    The canonical class is :class:`getstream.exceptions.StreamApiException`
-    (lowercase ``Api``); the old capitalised alias will be removed one minor
-    cycle after rollout.
-    """
+    """StreamApiException is exported under its new name; resolve here lazily and warn once."""
     if name == "StreamAPIException":
         warnings.warn(
             "getstream.base.StreamAPIException is deprecated; import "

--- a/getstream/exceptions.py
+++ b/getstream/exceptions.py
@@ -1,0 +1,344 @@
+"""Server-side SDK error hierarchy (CHA-2958).
+
+Per the Server-Side SDK Error Handling Spec §9.2, this module defines the
+canonical Python error hierarchy:
+
+    StreamException                — abstract base
+        StreamApiException         — HTTP 4xx/5xx with APIError envelope
+            StreamRateLimitException   — HTTP 429, carries ``retry_after``
+        StreamTransportException   — network-layer failure (no HTTP response)
+        StreamTaskException        — async task observed as ``status='failed'``
+
+Back-compat: ``getstream.base.StreamAPIException`` (capital ``API``) is an
+alias for ``StreamApiException`` for one minor cycle; importing the old name
+emits ``DeprecationWarning``.
+"""
+
+from __future__ import annotations
+
+import email.utils
+import json
+import socket
+import ssl
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import httpx
+
+from getstream.models import APIError
+from getstream.rate_limit import RateLimitInfo, extract_rate_limit
+
+
+TRANSPORT_ERROR_CONNECTION_RESET = "connection_reset"
+TRANSPORT_ERROR_TIMEOUT = "timeout"
+TRANSPORT_ERROR_DNS_FAILURE = "dns_failure"
+TRANSPORT_ERROR_TLS_HANDSHAKE_FAILED = "tls_handshake_failed"
+TRANSPORT_ERROR_UNKNOWN = "unknown"
+
+
+class StreamException(Exception):
+    """Abstract base for all Stream SDK errors."""
+
+
+class StreamApiException(StreamException):
+    """Raised on any HTTP 4xx/5xx response from the Stream API.
+
+    Also raised when an HTTP response was received but the body could not be
+    parsed as an ``APIError`` envelope (spec §6.3): in that case ``code`` is
+    ``0``, ``message`` is ``"failed to parse error response"``, and
+    ``__cause__`` is set to the underlying ``ValueError``/``AttributeError``
+    via ``raise ... from err`` at the call site (and via the ``response=``
+    constructor path internally).
+    """
+
+    def __init__(
+        self,
+        response: Optional[httpx.Response] = None,
+        *,
+        status_code: Optional[int] = None,
+        code: int = 0,
+        message: str = "",
+        exception_fields: Optional[Dict[str, str]] = None,
+        unrecoverable: bool = False,
+        raw_response_body: str = "",
+        more_info: Optional[str] = None,
+        details: Any = None,
+        api_error: Optional[APIError] = None,
+        rate_limit_info: Optional[RateLimitInfo] = None,
+    ) -> None:
+        body_parse_err: Optional[BaseException] = None
+        if response is not None:
+            parsed, body_parse_err = _fields_from_response(response)
+            status_code = parsed["status_code"]
+            code = parsed["code"]
+            message = parsed["message"]
+            exception_fields = parsed["exception_fields"]
+            unrecoverable = parsed["unrecoverable"]
+            raw_response_body = parsed["raw_response_body"]
+            more_info = parsed["more_info"]
+            details = parsed["details"]
+            api_error = parsed["api_error"]
+            rate_limit_info = parsed["rate_limit_info"]
+
+        if status_code is None:
+            raise TypeError(
+                "StreamApiException requires either a response or an explicit status_code"
+            )
+
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.exception_fields = exception_fields or {}
+        self.unrecoverable = unrecoverable
+        self.raw_response_body = raw_response_body
+        self.more_info = more_info
+        self.details = details
+        self.api_error = api_error
+        self.rate_limit_info = rate_limit_info
+        self.http_response = response
+        super().__init__(str(self))
+        if body_parse_err is not None and self.__cause__ is None:
+            self.__cause__ = body_parse_err
+
+    def __str__(self) -> str:
+        if self.code or self.message:
+            return (
+                f"Stream API error (status={self.status_code}, code={self.code}): "
+                f"{self.message}"
+            )
+        return f"Stream API error (status={self.status_code})"
+
+
+class StreamRateLimitException(StreamApiException):
+    """HTTP 429. Carries ``retry_after`` parsed from the ``Retry-After`` header.
+
+    ``retry_after`` is ``None`` when the header is absent or unparseable
+    (graceful — never raises on a bad header).
+    """
+
+    def __init__(
+        self,
+        response: Optional[httpx.Response] = None,
+        *,
+        retry_after: Optional[timedelta] = None,
+        **kwargs: Any,
+    ) -> None:
+        if response is not None and retry_after is None:
+            retry_after = parse_retry_after(response.headers.get("Retry-After"))
+        super().__init__(response, **kwargs)
+        self.retry_after = retry_after
+
+
+class StreamTransportException(StreamException):
+    """Network-layer failure: connection reset, timeout, TLS, DNS, etc.
+
+    No HTTP response was received. Callers MUST set ``__cause__`` via
+    ``raise StreamTransportException(...) from err`` so users can recover
+    the original transport error.
+    """
+
+    def __init__(self, error_type: str, message: str = "") -> None:
+        self.error_type = error_type
+        super().__init__(message or f"Stream transport error ({error_type})")
+
+
+class StreamTaskException(StreamException):
+    """Raised by ``wait_for_task`` when the polled task ends in
+    ``status='failed'``. Fields mirror the ``ErrorResult`` envelope on the
+    task-status response.
+    """
+
+    def __init__(
+        self,
+        *,
+        task_id: str,
+        error_type: str,
+        description: str,
+        stack_trace: Optional[str] = None,
+        version: Optional[str] = None,
+    ) -> None:
+        self.task_id = task_id
+        self.error_type = error_type
+        self.description = description
+        self.stack_trace = stack_trace
+        self.version = version
+        super().__init__(f"Task {task_id} failed ({error_type}): {description}")
+
+
+def _fields_from_response(
+    response: httpx.Response,
+) -> Tuple[Dict[str, Any], Optional[BaseException]]:
+    """Pull the §5.1 fields out of an httpx response.
+
+    Returns ``(fields, parse_error)`` where ``parse_error`` is the
+    ``ValueError`` or ``TypeError`` that prevented body decoding, or ``None``
+    when the body parsed cleanly as an ``APIError`` envelope (or the body was
+    empty).
+    """
+    raw_body = ""
+    try:
+        raw_body = response.text or ""
+    except Exception:
+        pass
+
+    api_error: Optional[APIError] = None
+    parse_error: Optional[BaseException] = None
+    if response.content:
+        try:
+            parsed_json: Any = json.loads(response.content)
+            api_error = APIError.from_dict(parsed_json)
+        except (ValueError, AttributeError, TypeError) as e:
+            api_error = None
+            parse_error = e
+
+    rate_limit_info = extract_rate_limit(response)
+
+    if api_error is not None:
+        unrecoverable = api_error.unrecoverable
+        return (
+            {
+                "status_code": response.status_code,
+                "code": api_error.code,
+                "message": api_error.message,
+                "exception_fields": dict(api_error.exception_fields or {}),
+                "unrecoverable": bool(unrecoverable)
+                if unrecoverable is not None
+                else False,
+                "raw_response_body": raw_body,
+                "more_info": api_error.more_info or None,
+                "details": api_error.details,
+                "api_error": api_error,
+                "rate_limit_info": rate_limit_info,
+            },
+            None,
+        )
+
+    return (
+        {
+            "status_code": response.status_code,
+            "code": 0,
+            "message": "failed to parse error response",
+            "exception_fields": {},
+            "unrecoverable": False,
+            "raw_response_body": raw_body,
+            "more_info": None,
+            "details": None,
+            "api_error": None,
+            "rate_limit_info": rate_limit_info,
+        },
+        parse_error,
+    )
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_retry_after(
+    header_value: Optional[str],
+    *,
+    now: Callable[[], datetime] = _utcnow,
+) -> Optional[timedelta]:
+    """Parse ``Retry-After`` per RFC 7231 §7.1.3.
+
+    Accepts integer seconds (``Retry-After: 30``) or HTTP-date
+    (``Retry-After: Fri, 31 Dec 2026 23:59:59 GMT``). Returns ``None`` when
+    the header is absent or unparseable. HTTP-date deltas in the past are
+    clamped to zero (never negative).
+    """
+    if header_value is None:
+        return None
+    value = header_value.strip()
+    if not value:
+        return None
+    try:
+        seconds = int(value)
+    except ValueError:
+        pass
+    else:
+        if seconds < 0:
+            return None
+        return timedelta(seconds=seconds)
+
+    try:
+        parsed = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    delta = parsed - now()
+    if delta.total_seconds() < 0:
+        return timedelta(0)
+    return delta
+
+
+def build_api_exception(response: httpx.Response) -> StreamApiException:
+    """Build the right ``StreamApiException`` subclass from an httpx response.
+
+    * 429 → ``StreamRateLimitException`` with parsed ``Retry-After``.
+    * otherwise → base ``StreamApiException``.
+
+    The ``__cause__`` chain is populated from any body-parse failure
+    encountered while extracting the ``APIError`` envelope (spec §6.3).
+    """
+    if response.status_code == 429:
+        return StreamRateLimitException(response=response)
+    return StreamApiException(response=response)
+
+
+def classify_transport_error(exc: BaseException) -> str:
+    """Map an httpx transport-layer exception to the spec ``error_type`` enum.
+
+    Walks the ``__cause__``/``__context__`` chain to catch the underlying
+    ``ssl.SSLError`` or ``socket.gaierror`` that httpx wraps. Falls back to
+    generic ``connection_reset`` for network errors and ``unknown`` for
+    anything we don't recognize.
+    """
+    if isinstance(exc, httpx.TimeoutException):
+        return TRANSPORT_ERROR_TIMEOUT
+
+    seen: set = set()
+    cur: Optional[BaseException] = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, ssl.SSLError):
+            return TRANSPORT_ERROR_TLS_HANDSHAKE_FAILED
+        if isinstance(cur, socket.gaierror):
+            return TRANSPORT_ERROR_DNS_FAILURE
+        cur = cur.__cause__ or cur.__context__
+
+    if isinstance(exc, (httpx.NetworkError, httpx.TransportError)):
+        return TRANSPORT_ERROR_CONNECTION_RESET
+    return TRANSPORT_ERROR_UNKNOWN
+
+
+def wrap_transport_error(exc: httpx.RequestError) -> StreamTransportException:
+    """Build a ``StreamTransportException`` from an httpx ``RequestError``.
+
+    Caller is expected to ``raise ... from exc`` so ``__cause__`` is set per
+    spec §6.4.
+    """
+    return StreamTransportException(
+        error_type=classify_transport_error(exc),
+        message=f"transport error: {exc}",
+    )
+
+
+__all__ = [
+    "StreamException",
+    "StreamApiException",
+    "StreamRateLimitException",
+    "StreamTransportException",
+    "StreamTaskException",
+    "TRANSPORT_ERROR_CONNECTION_RESET",
+    "TRANSPORT_ERROR_TIMEOUT",
+    "TRANSPORT_ERROR_DNS_FAILURE",
+    "TRANSPORT_ERROR_TLS_HANDSHAKE_FAILED",
+    "TRANSPORT_ERROR_UNKNOWN",
+    "build_api_exception",
+    "classify_transport_error",
+    "parse_retry_after",
+    "wrap_transport_error",
+]

--- a/getstream/exceptions.py
+++ b/getstream/exceptions.py
@@ -1,17 +1,10 @@
-"""Server-side SDK error hierarchy (CHA-2958).
+"""Stream SDK error hierarchy. See class docstrings for when each is raised.
 
-Per the Server-Side SDK Error Handling Spec §9.2, this module defines the
-canonical Python error hierarchy:
-
-    StreamException                — abstract base
-        StreamApiException         — HTTP 4xx/5xx with APIError envelope
-            StreamRateLimitException   — HTTP 429, carries ``retry_after``
-        StreamTransportException   — network-layer failure (no HTTP response)
-        StreamTaskException        — async task observed as ``status='failed'``
-
-Back-compat: ``getstream.base.StreamAPIException`` (capital ``API``) is an
-alias for ``StreamApiException`` for one minor cycle; importing the old name
-emits ``DeprecationWarning``.
+StreamException                — abstract base
+    StreamApiException         — HTTP 4xx/5xx with APIError envelope
+        StreamRateLimitException   — HTTP 429, carries ``retry_after``
+    StreamTransportException   — network-layer failure (no HTTP response)
+    StreamTaskException        — async task observed as ``status='failed'``
 """
 
 from __future__ import annotations
@@ -43,12 +36,10 @@ class StreamException(Exception):
 class StreamApiException(StreamException):
     """Raised on any HTTP 4xx/5xx response from the Stream API.
 
-    Also raised when an HTTP response was received but the body could not be
-    parsed as an ``APIError`` envelope (spec §6.3): in that case ``code`` is
-    ``0``, ``message`` is ``"failed to parse error response"``, and
-    ``__cause__`` is set to the underlying ``ValueError``/``AttributeError``
-    via ``raise ... from err`` at the call site (and via the ``response=``
-    constructor path internally).
+    Raised with code=0 and message='failed to parse error response' when an
+    HTTP response was received but the body could not be parsed as an
+    APIError envelope; in that case ``__cause__`` carries the underlying
+    parse error.
     """
 
     def __init__(
@@ -132,9 +123,8 @@ class StreamRateLimitException(StreamApiException):
 class StreamTransportException(StreamException):
     """Network-layer failure: connection reset, timeout, TLS, DNS, etc.
 
-    No HTTP response was received. Callers MUST set ``__cause__`` via
-    ``raise StreamTransportException(...) from err`` so users can recover
-    the original transport error.
+    No HTTP response was received. ``__cause__`` carries the original httpx
+    exception.
     """
 
     def __init__(self, error_type: str, message: str = "") -> None:
@@ -144,8 +134,8 @@ class StreamTransportException(StreamException):
 
 class StreamTaskException(StreamException):
     """Raised by ``wait_for_task`` when the polled task ends in
-    ``status='failed'``. Fields mirror the ``ErrorResult`` envelope on the
-    task-status response.
+    status='failed'. Carries task_id, error_type, description, stack_trace,
+    version.
     """
 
     def __init__(
@@ -168,12 +158,10 @@ class StreamTaskException(StreamException):
 def _fields_from_response(
     response: httpx.Response,
 ) -> Tuple[Dict[str, Any], Optional[BaseException]]:
-    """Pull the §5.1 fields out of an httpx response.
+    """Pull the APIError envelope fields out of an httpx response.
 
-    Returns ``(fields, parse_error)`` where ``parse_error`` is the
-    ``ValueError`` or ``TypeError`` that prevented body decoding, or ``None``
-    when the body parsed cleanly as an ``APIError`` envelope (or the body was
-    empty).
+    Returns ``(fields, parse_error)``; ``parse_error`` is None when the body
+    parsed cleanly or was empty.
     """
     raw_body = ""
     try:
@@ -277,11 +265,9 @@ def parse_retry_after(
 def build_api_exception(response: httpx.Response) -> StreamApiException:
     """Build the right ``StreamApiException`` subclass from an httpx response.
 
-    * 429 → ``StreamRateLimitException`` with parsed ``Retry-After``.
-    * otherwise → base ``StreamApiException``.
-
-    The ``__cause__`` chain is populated from any body-parse failure
-    encountered while extracting the ``APIError`` envelope (spec §6.3).
+    Returns ``StreamRateLimitException`` for 429, else base
+    ``StreamApiException``. ``__cause__`` is set when the body could not be
+    parsed.
     """
     if response.status_code == 429:
         return StreamRateLimitException(response=response)
@@ -289,12 +275,9 @@ def build_api_exception(response: httpx.Response) -> StreamApiException:
 
 
 def classify_transport_error(exc: BaseException) -> str:
-    """Map an httpx transport-layer exception to the spec ``error_type`` enum.
-
-    Walks the ``__cause__``/``__context__`` chain to catch the underlying
-    ``ssl.SSLError`` or ``socket.gaierror`` that httpx wraps. Falls back to
-    generic ``connection_reset`` for network errors and ``unknown`` for
-    anything we don't recognize.
+    """Map an httpx transport exception to the ``error_type`` enum: ``timeout``,
+    ``tls_handshake_failed``, ``dns_failure``, ``connection_reset``, or
+    ``unknown``.
     """
     if isinstance(exc, httpx.TimeoutException):
         return TRANSPORT_ERROR_TIMEOUT
@@ -317,8 +300,7 @@ def classify_transport_error(exc: BaseException) -> str:
 def wrap_transport_error(exc: httpx.RequestError) -> StreamTransportException:
     """Build a ``StreamTransportException`` from an httpx ``RequestError``.
 
-    Caller is expected to ``raise ... from exc`` so ``__cause__`` is set per
-    spec §6.4.
+    Callers must use ``raise ... from exc`` to set ``__cause__``.
     """
     return StreamTransportException(
         error_type=classify_transport_error(exc),

--- a/getstream/stream.py
+++ b/getstream/stream.py
@@ -408,6 +408,24 @@ class AsyncStream(BaseStream, AsyncCommonClient):
                 stack.push_async_callback(self.moderation.aclose)
             stack.push_async_callback(super().aclose)
 
+    async def wait_for_task(
+        self,
+        task_id: str,
+        *,
+        poll_interval: float = 1.0,
+        timeout: float = 60.0,
+    ):
+        """Poll an async task until ``completed`` (returns the response),
+        ``failed`` (raises :class:`StreamTaskException`), or the timeout
+        elapses (raises :class:`StreamTransportException` with
+        ``error_type='timeout'``). See CHA-2958 §8.
+        """
+        from .tasks import wait_for_task_async
+
+        return await wait_for_task_async(
+            self, task_id, poll_interval=poll_interval, timeout=timeout
+        )
+
     @cached_property
     def feeds(self):
         raise NotImplementedError("Feeds not supported for async client")
@@ -620,6 +638,24 @@ class Stream(BaseStream, CommonClient):
         """
         users_map = {u.id: u for u in users}
         return self.update_users(users_map)
+
+    def wait_for_task(
+        self,
+        task_id: str,
+        *,
+        poll_interval: float = 1.0,
+        timeout: float = 60.0,
+    ):
+        """Poll an async task until ``completed`` (returns the response),
+        ``failed`` (raises :class:`StreamTaskException`), or the timeout
+        elapses (raises :class:`StreamTransportException` with
+        ``error_type='timeout'``). See CHA-2958 §8.
+        """
+        from .tasks import wait_for_task_sync
+
+        return wait_for_task_sync(
+            self, task_id, poll_interval=poll_interval, timeout=timeout
+        )
 
     def verify_signature(self, body, signature):
         """Verify a webhook signature using this client's API secret.

--- a/getstream/stream.py
+++ b/getstream/stream.py
@@ -418,7 +418,7 @@ class AsyncStream(BaseStream, AsyncCommonClient):
         """Poll an async task until ``completed`` (returns the response),
         ``failed`` (raises :class:`StreamTaskException`), or the timeout
         elapses (raises :class:`StreamTransportException` with
-        ``error_type='timeout'``). See CHA-2958 §8.
+        ``error_type='timeout'``).
         """
         from .tasks import wait_for_task_async
 
@@ -649,7 +649,7 @@ class Stream(BaseStream, CommonClient):
         """Poll an async task until ``completed`` (returns the response),
         ``failed`` (raises :class:`StreamTaskException`), or the timeout
         elapses (raises :class:`StreamTransportException` with
-        ``error_type='timeout'``). See CHA-2958 §8.
+        ``error_type='timeout'``).
         """
         from .tasks import wait_for_task_sync
 

--- a/getstream/tasks.py
+++ b/getstream/tasks.py
@@ -1,14 +1,4 @@
-"""Task-waiting helpers (CHA-2958 §8).
-
-Sync and async polling helpers that wait for an async task to reach a
-terminal state. On ``status='failed'`` they raise ``StreamTaskException``
-populated from the task's ``ErrorResult``; on timeout they raise
-``StreamTransportException`` with ``error_type='timeout'``.
-
-The public surface for SDK users is the ``wait_for_task`` method on
-``Stream``/``AsyncStream`` (see ``getstream.stream``); the functions here
-are reused by both.
-"""
+"""Polling helpers used by ``Stream.wait_for_task`` and ``AsyncStream.wait_for_task``."""
 
 from __future__ import annotations
 
@@ -90,11 +80,7 @@ async def wait_for_task_async(
     poll_interval: float = DEFAULT_POLL_INTERVAL,
     timeout: float = DEFAULT_TIMEOUT,
 ) -> "StreamResponse[GetTaskResponse]":
-    """Async variant of :func:`wait_for_task_sync`.
-
-    Uses ``asyncio.get_running_loop().time()`` for the deadline so callers
-    don't pay for instantiating a default loop when none exists.
-    """
+    """Async variant of :func:`wait_for_task_sync`."""
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     while True:

--- a/getstream/tasks.py
+++ b/getstream/tasks.py
@@ -1,0 +1,118 @@
+"""Task-waiting helpers (CHA-2958 §8).
+
+Sync and async polling helpers that wait for an async task to reach a
+terminal state. On ``status='failed'`` they raise ``StreamTaskException``
+populated from the task's ``ErrorResult``; on timeout they raise
+``StreamTransportException`` with ``error_type='timeout'``.
+
+The public surface for SDK users is the ``wait_for_task`` method on
+``Stream``/``AsyncStream`` (see ``getstream.stream``); the functions here
+are reused by both.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any
+
+from getstream.exceptions import (
+    StreamTaskException,
+    StreamTransportException,
+    TRANSPORT_ERROR_TIMEOUT,
+)
+
+if TYPE_CHECKING:
+    from getstream.models import GetTaskResponse
+    from getstream.stream_response import StreamResponse
+
+
+DEFAULT_POLL_INTERVAL = 1.0
+DEFAULT_TIMEOUT = 60.0
+
+
+def _build_task_exception(task_id: str, response_data: Any) -> StreamTaskException:
+    """Construct a ``StreamTaskException`` from a ``GetTaskResponse.data``.
+
+    Missing ``error`` (shouldn't happen when status == 'failed' but defend
+    anyway) collapses to ``error_type='unknown'`` with an empty description.
+    """
+    err = getattr(response_data, "error", None)
+    return StreamTaskException(
+        task_id=task_id,
+        error_type=err.type if err is not None else "unknown",
+        description=err.description if err is not None else "",
+        stack_trace=err.stacktrace if err is not None else None,
+        version=err.version if err is not None else None,
+    )
+
+
+def _timeout_exception(task_id: str, timeout: float) -> StreamTransportException:
+    return StreamTransportException(
+        error_type=TRANSPORT_ERROR_TIMEOUT,
+        message=(
+            f"wait_for_task timed out after {timeout}s waiting for task {task_id}"
+        ),
+    )
+
+
+def wait_for_task_sync(
+    client: Any,
+    task_id: str,
+    *,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> "StreamResponse[GetTaskResponse]":
+    """Poll ``client.get_task(id=task_id)`` (sync) until terminal state.
+
+    Returns the ``StreamResponse`` on ``completed``. Raises
+    ``StreamTaskException`` on ``failed``, ``StreamTransportException`` with
+    ``error_type='timeout'`` if ``timeout`` elapses first.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        response = client.get_task(id=task_id)
+        status = response.data.status
+        if status == "completed":
+            return response
+        if status == "failed":
+            raise _build_task_exception(task_id, response.data)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _timeout_exception(task_id, timeout)
+        time.sleep(min(poll_interval, remaining))
+
+
+async def wait_for_task_async(
+    client: Any,
+    task_id: str,
+    *,
+    poll_interval: float = DEFAULT_POLL_INTERVAL,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> "StreamResponse[GetTaskResponse]":
+    """Async variant of :func:`wait_for_task_sync`.
+
+    Uses ``asyncio.get_running_loop().time()`` for the deadline so callers
+    don't pay for instantiating a default loop when none exists.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        response = await client.get_task(id=task_id)
+        status = response.data.status
+        if status == "completed":
+            return response
+        if status == "failed":
+            raise _build_task_exception(task_id, response.data)
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise _timeout_exception(task_id, timeout)
+        await asyncio.sleep(min(poll_interval, remaining))
+
+
+__all__ = [
+    "DEFAULT_POLL_INTERVAL",
+    "DEFAULT_TIMEOUT",
+    "wait_for_task_sync",
+    "wait_for_task_async",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dev = [
     "prometheus-client>=0.23.1",
     "torch>=2.7.0",  # Only for scripts/create_test_assets.py
     "torchaudio>=2.7.0",  # Only for scripts/create_test_assets.py
+    "pytest-httpserver>=1.1.5",
 ]
 
 [tool.uv.workspace]

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,549 @@
+"""Unit tests for the new error hierarchy (CHA-2958).
+
+Covers:
+* The four canonical exception classes and their fields.
+* APIError envelope parsing into ``StreamApiException`` (incl. spec §6.3
+  unparseable-envelope fallback).
+* ``Retry-After`` parsing (integer + HTTP-date forms; missing/garbage).
+* Transport-error wrapping with ``__cause__`` preserved.
+* ``wait_for_task`` sync + async (completed / failed / timeout).
+* Back-compat: ``getstream.base.StreamAPIException`` still importable, still
+  catchable, emits ``DeprecationWarning``.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import ssl
+import warnings
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import httpx
+import pytest
+
+from getstream.exceptions import (
+    StreamApiException,
+    StreamException,
+    StreamRateLimitException,
+    StreamTaskException,
+    StreamTransportException,
+    TRANSPORT_ERROR_CONNECTION_RESET,
+    TRANSPORT_ERROR_DNS_FAILURE,
+    TRANSPORT_ERROR_TIMEOUT,
+    TRANSPORT_ERROR_TLS_HANDSHAKE_FAILED,
+    TRANSPORT_ERROR_UNKNOWN,
+    build_api_exception,
+    classify_transport_error,
+    parse_retry_after,
+    wrap_transport_error,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+def _make_response(
+    status_code: int,
+    body: Optional[dict] = None,
+    headers: Optional[dict] = None,
+    raw_text: Optional[str] = None,
+) -> httpx.Response:
+    """Build an ``httpx.Response`` with no real network round-trip."""
+    if raw_text is not None:
+        content: bytes = raw_text.encode("utf-8")
+    elif body is not None:
+        content = json.dumps(body).encode("utf-8")
+    else:
+        content = b""
+    request = httpx.Request("GET", "https://example.invalid/test")
+    return httpx.Response(
+        status_code=status_code,
+        content=content,
+        headers=headers or {},
+        request=request,
+    )
+
+
+# ── Class hierarchy ───────────────────────────────────────────────────
+
+
+def test_class_hierarchy_matches_spec_9_2():
+    """The four concrete classes plus the abstract base all inherit from
+    ``StreamException`` per §9.2."""
+    assert issubclass(StreamApiException, StreamException)
+    assert issubclass(StreamRateLimitException, StreamApiException)
+    assert issubclass(StreamTransportException, StreamException)
+    assert issubclass(StreamTaskException, StreamException)
+
+
+def test_api_exception_explicit_kwargs():
+    exc = StreamApiException(
+        status_code=404,
+        code=16,
+        message="not found",
+        exception_fields={"id": "missing"},
+        unrecoverable=True,
+        raw_response_body='{"code":16}',
+        more_info="https://example.com/docs",
+        details=["x"],
+    )
+    assert exc.status_code == 404
+    assert exc.code == 16
+    assert exc.message == "not found"
+    assert exc.exception_fields == {"id": "missing"}
+    assert exc.unrecoverable is True
+    assert exc.raw_response_body == '{"code":16}'
+    assert exc.more_info == "https://example.com/docs"
+    assert exc.details == ["x"]
+
+
+def test_api_exception_requires_status_code_without_response():
+    with pytest.raises(TypeError):
+        StreamApiException()
+
+
+# ── APIError envelope parsing ─────────────────────────────────────────
+
+
+def test_api_exception_from_response_extracts_all_fields():
+    body = {
+        "StatusCode": 422,
+        "code": 4,
+        "duration": "12ms",
+        "message": "validation failed",
+        "more_info": "https://docs/422",
+        "details": [1, 2, 3],
+        "exception_fields": {"name": "required"},
+        "unrecoverable": False,
+    }
+    response = _make_response(422, body=body)
+    exc = build_api_exception(response)
+    assert isinstance(exc, StreamApiException)
+    assert not isinstance(exc, StreamRateLimitException)
+    assert exc.status_code == 422
+    assert exc.code == 4
+    assert exc.message == "validation failed"
+    assert exc.exception_fields == {"name": "required"}
+    assert exc.unrecoverable is False
+    assert exc.more_info == "https://docs/422"
+    assert exc.details == [1, 2, 3]
+    assert exc.raw_response_body == json.dumps(body)
+
+
+def test_api_exception_exposes_unrecoverable_when_set_true():
+    body = {
+        "StatusCode": 400,
+        "code": 99,
+        "duration": "0ms",
+        "message": "do not retry",
+        "more_info": "",
+        "details": [],
+        "exception_fields": None,
+        "unrecoverable": True,
+    }
+    exc = build_api_exception(_make_response(400, body=body))
+    assert exc.unrecoverable is True
+
+
+def test_api_exception_unparseable_body_falls_back_per_spec_6_3():
+    response = _make_response(500, raw_text="<html>upstream barfed</html>")
+    exc = build_api_exception(response)
+    assert exc.status_code == 500
+    assert exc.code == 0
+    assert exc.message == "failed to parse error response"
+    assert exc.exception_fields == {}
+    assert exc.unrecoverable is False
+    assert exc.raw_response_body == "<html>upstream barfed</html>"
+    assert exc.api_error is None
+
+
+def test_api_exception_back_compat_attrs_preserved():
+    """The old API surface (api_error, http_response, rate_limit_info,
+    status_code) keeps working — none of the existing tests can break."""
+    body = {
+        "StatusCode": 401,
+        "code": 17,
+        "duration": "0ms",
+        "message": "denied",
+        "more_info": "",
+        "details": [],
+        "exception_fields": None,
+    }
+    response = _make_response(401, body=body, headers={"x-ratelimit-limit": "10"})
+    exc = build_api_exception(response)
+    assert exc.http_response is response
+    assert exc.status_code == 401
+    assert exc.api_error is not None
+    assert exc.api_error.code == 17
+    # rate_limit_info requires all three headers; only partial here → None.
+    assert exc.rate_limit_info is None
+
+
+# ── Retry-After handling (§7) ─────────────────────────────────────────
+
+
+def test_parse_retry_after_integer_seconds():
+    assert parse_retry_after("30") == timedelta(seconds=30)
+
+
+def test_parse_retry_after_http_date():
+    fake_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    delta = parse_retry_after(
+        "Thu, 01 Jan 2026 12:00:30 GMT",
+        now=lambda: fake_now,
+    )
+    assert delta == timedelta(seconds=30)
+
+
+def test_parse_retry_after_past_http_date_clamped_to_zero():
+    fake_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    delta = parse_retry_after(
+        "Thu, 01 Jan 2026 11:59:30 GMT",
+        now=lambda: fake_now,
+    )
+    assert delta == timedelta(0)
+
+
+def test_parse_retry_after_missing_or_unparseable_returns_none():
+    assert parse_retry_after(None) is None
+    assert parse_retry_after("") is None
+    assert parse_retry_after("   ") is None
+    assert parse_retry_after("not a date or number") is None
+
+
+def test_parse_retry_after_negative_integer_returns_none():
+    assert parse_retry_after("-1") is None
+
+
+def test_429_builds_rate_limit_exception_with_retry_after():
+    body = {
+        "StatusCode": 429,
+        "code": 9,
+        "duration": "0ms",
+        "message": "slow down",
+        "more_info": "",
+        "details": [],
+        "exception_fields": None,
+    }
+    response = _make_response(429, body=body, headers={"Retry-After": "5"})
+    exc = build_api_exception(response)
+    assert isinstance(exc, StreamRateLimitException)
+    # Subclass of StreamApiException — existing 4xx handlers still catch it.
+    assert isinstance(exc, StreamApiException)
+    assert exc.retry_after == timedelta(seconds=5)
+    assert exc.status_code == 429
+    assert exc.message == "slow down"
+
+
+def test_429_without_retry_after_header_is_none():
+    body = {
+        "StatusCode": 429,
+        "code": 9,
+        "duration": "0ms",
+        "message": "slow down",
+        "more_info": "",
+        "details": [],
+        "exception_fields": None,
+    }
+    response = _make_response(429, body=body)
+    exc = build_api_exception(response)
+    assert isinstance(exc, StreamRateLimitException)
+    assert exc.retry_after is None
+
+
+def test_retry_after_exposed_only_on_rate_limit_subclass():
+    body = {
+        "StatusCode": 500,
+        "code": 1,
+        "duration": "0ms",
+        "message": "boom",
+        "more_info": "",
+        "details": [],
+        "exception_fields": None,
+    }
+    response = _make_response(500, body=body, headers={"Retry-After": "5"})
+    exc = build_api_exception(response)
+    assert isinstance(exc, StreamApiException)
+    assert not isinstance(exc, StreamRateLimitException)
+    assert not hasattr(exc, "retry_after")
+
+
+# ── Transport-error wrapping (§6.1, §6.4) ─────────────────────────────
+
+
+def _request() -> httpx.Request:
+    return httpx.Request("GET", "https://example.invalid/test")
+
+
+def test_classify_timeout():
+    err = httpx.ReadTimeout("timed out", request=_request())
+    assert classify_transport_error(err) == TRANSPORT_ERROR_TIMEOUT
+
+
+def test_classify_tls_via_cause_chain():
+    inner = ssl.SSLError("handshake failed")
+    outer = httpx.ConnectError("ssl wrapper", request=_request())
+    outer.__cause__ = inner
+    assert classify_transport_error(outer) == TRANSPORT_ERROR_TLS_HANDSHAKE_FAILED
+
+
+def test_classify_dns_via_cause_chain():
+    inner = socket.gaierror("name or service not known")
+    outer = httpx.ConnectError("dns wrapper", request=_request())
+    outer.__cause__ = inner
+    assert classify_transport_error(outer) == TRANSPORT_ERROR_DNS_FAILURE
+
+
+def test_classify_connection_reset_default():
+    outer = httpx.ConnectError("connection refused", request=_request())
+    assert classify_transport_error(outer) == TRANSPORT_ERROR_CONNECTION_RESET
+
+
+def test_classify_unknown_for_non_transport_error():
+    class WeirdError(Exception):
+        pass
+
+    assert classify_transport_error(WeirdError("?")) == TRANSPORT_ERROR_UNKNOWN
+
+
+def test_wrap_transport_error_builds_exception_class():
+    err = httpx.ConnectTimeout("timed out", request=_request())
+    wrapped = wrap_transport_error(err)
+    assert isinstance(wrapped, StreamTransportException)
+    assert wrapped.error_type == TRANSPORT_ERROR_TIMEOUT
+
+
+def test_transport_exception_cause_chain_preserved():
+    """``raise StreamTransportException(...) from err`` must keep the
+    underlying httpx error on ``__cause__`` per spec §6.4."""
+    err = httpx.ConnectError("refused", request=_request())
+    try:
+        raise wrap_transport_error(err) from err
+    except StreamTransportException as caught:
+        assert caught.__cause__ is err
+        assert caught.error_type == TRANSPORT_ERROR_CONNECTION_RESET
+
+
+def test_transport_wrapping_via_mock_transport_sync(monkeypatch):
+    """End-to-end: an ``httpx`` transport error inside the SDK sync path is
+    re-raised as ``StreamTransportException`` with the original on
+    ``__cause__``."""
+    from getstream import Stream
+
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("network down", request=request)
+
+    transport = httpx.MockTransport(boom)
+    monkeypatch.delenv("STREAM_API_KEY", raising=False)
+    monkeypatch.delenv("STREAM_API_SECRET", raising=False)
+    client = Stream(
+        api_key="k",
+        api_secret="s",
+        base_url="https://example.invalid/",
+        transport=transport,
+    )
+    try:
+        with pytest.raises(StreamTransportException) as info:
+            client.get_app()
+        assert info.value.error_type in {
+            TRANSPORT_ERROR_CONNECTION_RESET,
+            TRANSPORT_ERROR_UNKNOWN,
+        }
+        assert isinstance(info.value.__cause__, httpx.ConnectError)
+    finally:
+        client.close()
+
+
+async def test_transport_wrapping_via_mock_transport_async(monkeypatch):
+    """End-to-end async path mirrors the sync test."""
+    from getstream import AsyncStream
+
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("read timed out", request=request)
+
+    transport = httpx.MockTransport(boom)
+    monkeypatch.delenv("STREAM_API_KEY", raising=False)
+    monkeypatch.delenv("STREAM_API_SECRET", raising=False)
+
+    client = AsyncStream(
+        api_key="k",
+        api_secret="s",
+        base_url="https://example.invalid/",
+        transport=transport,
+    )
+    try:
+        with pytest.raises(StreamTransportException) as info:
+            await client.get_app()
+        assert info.value.error_type == TRANSPORT_ERROR_TIMEOUT
+        assert isinstance(info.value.__cause__, httpx.ReadTimeout)
+    finally:
+        await client.aclose()
+
+
+# ── Back-compat alias ─────────────────────────────────────────────────
+
+
+def test_legacy_alias_still_importable_with_deprecation_warning():
+    """``from getstream.base import StreamAPIException`` keeps working but
+    emits ``DeprecationWarning`` per spec §10."""
+    import getstream.base as base_mod
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        legacy = getattr(base_mod, "StreamAPIException")
+        assert legacy is StreamApiException
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and "StreamAPIException is deprecated" in str(w.message)
+            for w in caught
+        )
+
+
+def test_legacy_alias_catches_new_exception():
+    """Code that does ``except StreamAPIException`` keeps catching exceptions
+    raised by the new code path."""
+    from getstream.base import StreamAPIException
+
+    raised = StreamApiException(status_code=500, message="boom")
+    with pytest.raises(StreamAPIException) as info:
+        raise raised
+    assert info.value is raised
+
+
+# ── wait_for_task (§8) ────────────────────────────────────────────────
+
+
+class _FakeError:
+    def __init__(self, type_: str, description: str, stack=None, version=None):
+        self.type = type_
+        self.description = description
+        self.stacktrace = stack
+        self.version = version
+
+
+class _FakeTaskData:
+    def __init__(self, status: str, error: Optional[_FakeError] = None):
+        self.status = status
+        self.error = error
+
+
+class _FakeResponse:
+    def __init__(self, status: str, error: Optional[_FakeError] = None):
+        self.data = _FakeTaskData(status, error)
+
+
+class _FakeSyncClient:
+    """Sync stand-in for a ``Stream`` client; ``get_task`` returns the next
+    scripted response, repeating the last one indefinitely once the list is
+    drained so timeout tests don't run out of mock data."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def get_task(self, *, id):
+        self.calls += 1
+        if len(self._responses) > 1:
+            return self._responses.pop(0)
+        return self._responses[0]
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def get_task(self, *, id):
+        self.calls += 1
+        if len(self._responses) > 1:
+            return self._responses.pop(0)
+        return self._responses[0]
+
+
+def test_wait_for_task_sync_returns_on_completed():
+    from getstream.tasks import wait_for_task_sync
+
+    client = _FakeSyncClient([_FakeResponse("waiting"), _FakeResponse("completed")])
+    result = wait_for_task_sync(client, "task-1", poll_interval=0.0, timeout=5.0)
+    assert result.data.status == "completed"
+    assert client.calls == 2
+
+
+def test_wait_for_task_sync_raises_on_failed():
+    from getstream.tasks import wait_for_task_sync
+
+    err = _FakeError("ImportFailed", "bad rows", stack="trace", version="v1")
+    client = _FakeSyncClient([_FakeResponse("failed", err)])
+    with pytest.raises(StreamTaskException) as info:
+        wait_for_task_sync(client, "task-fail", poll_interval=0.0, timeout=5.0)
+    exc = info.value
+    assert exc.task_id == "task-fail"
+    assert exc.error_type == "ImportFailed"
+    assert exc.description == "bad rows"
+    assert exc.stack_trace == "trace"
+    assert exc.version == "v1"
+
+
+def test_wait_for_task_sync_times_out_raises_transport_exception():
+    from getstream.tasks import wait_for_task_sync
+
+    # Always 'waiting' — must time out.
+    client = _FakeSyncClient([_FakeResponse("waiting") for _ in range(50)])
+    with pytest.raises(StreamTransportException) as info:
+        wait_for_task_sync(client, "task-timeout", poll_interval=0.0, timeout=0.01)
+    assert info.value.error_type == TRANSPORT_ERROR_TIMEOUT
+
+
+async def test_wait_for_task_async_returns_on_completed():
+    from getstream.tasks import wait_for_task_async
+
+    client = _FakeAsyncClient([_FakeResponse("waiting"), _FakeResponse("completed")])
+    result = await wait_for_task_async(client, "task-1", poll_interval=0.0, timeout=5.0)
+    assert result.data.status == "completed"
+
+
+async def test_wait_for_task_async_raises_on_failed():
+    from getstream.tasks import wait_for_task_async
+
+    err = _FakeError("ImportFailed", "async bad", stack=None, version=None)
+    client = _FakeAsyncClient([_FakeResponse("failed", err)])
+
+    with pytest.raises(StreamTaskException) as info:
+        await wait_for_task_async(client, "task-fail", poll_interval=0.0, timeout=5.0)
+    assert info.value.task_id == "task-fail"
+    assert info.value.description == "async bad"
+
+
+async def test_wait_for_task_async_times_out_raises_transport_exception():
+    from getstream.tasks import wait_for_task_async
+
+    client = _FakeAsyncClient([_FakeResponse("waiting") for _ in range(50)])
+    with pytest.raises(StreamTransportException) as info:
+        await wait_for_task_async(
+            client, "task-timeout", poll_interval=0.0, timeout=0.01
+        )
+    assert info.value.error_type == TRANSPORT_ERROR_TIMEOUT
+
+
+# ── StreamTaskException construction ──────────────────────────────────
+
+
+def test_stream_task_exception_fields():
+    exc = StreamTaskException(
+        task_id="t-9",
+        error_type="ImportFailed",
+        description="boom",
+        stack_trace="trace",
+        version="v3",
+    )
+    assert exc.task_id == "t-9"
+    assert exc.error_type == "ImportFailed"
+    assert exc.description == "boom"
+    assert exc.stack_trace == "trace"
+    assert exc.version == "v3"
+    # Optional fields default to None when not supplied.
+    bare = StreamTaskException(task_id="t-0", error_type="x", description="y")
+    assert bare.stack_trace is None
+    assert bare.version is None

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -326,23 +326,28 @@ def test_transport_exception_cause_chain_preserved():
         assert caught.error_type == TRANSPORT_ERROR_CONNECTION_RESET
 
 
-def test_transport_wrapping_via_mock_transport_sync(monkeypatch):
-    """End-to-end: an ``httpx`` transport error inside the SDK sync path is
-    re-raised as ``StreamTransportException`` with the original on
-    ``__cause__``."""
+def _closed_port() -> int:
+    """Bind a loopback socket, close it, and return the now-closed port.
+    Connecting to it triggers a real ``httpx.ConnectError``."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def test_transport_wrapping_sync_connection_refused(monkeypatch):
+    """End-to-end: a real ``httpx.ConnectError`` (loopback port closed) is
+    re-raised by the SDK as ``StreamTransportException`` with the original
+    on ``__cause__``."""
     from getstream import Stream
 
-    def boom(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("network down", request=request)
-
-    transport = httpx.MockTransport(boom)
     monkeypatch.delenv("STREAM_API_KEY", raising=False)
     monkeypatch.delenv("STREAM_API_SECRET", raising=False)
     client = Stream(
         api_key="k",
         api_secret="s",
-        base_url="https://example.invalid/",
-        transport=transport,
+        base_url=f"http://127.0.0.1:{_closed_port()}/",
     )
     try:
         with pytest.raises(StreamTransportException) as info:
@@ -356,28 +361,37 @@ def test_transport_wrapping_via_mock_transport_sync(monkeypatch):
         client.close()
 
 
-async def test_transport_wrapping_via_mock_transport_async(monkeypatch):
-    """End-to-end async path mirrors the sync test."""
+async def test_transport_wrapping_async_read_timeout(httpserver, monkeypatch):
+    """A real local server that delays the response longer than the client
+    read-timeout triggers ``httpx.ReadTimeout``, wrapped by the SDK as
+    ``StreamTransportException`` with ``error_type='timeout'``."""
+    import time
+
     from getstream import AsyncStream
 
-    def boom(request: httpx.Request) -> httpx.Response:
-        raise httpx.ReadTimeout("read timed out", request=request)
+    from werkzeug.wrappers import Response as WerkzeugResponse
 
-    transport = httpx.MockTransport(boom)
+    def slow_handler(_request):
+        time.sleep(1.0)  # exceed the client's read timeout below
+        return WerkzeugResponse("{}", status=200, content_type="application/json")
+
+    httpserver.expect_request("/api/v2/app").respond_with_handler(slow_handler)
+
     monkeypatch.delenv("STREAM_API_KEY", raising=False)
     monkeypatch.delenv("STREAM_API_SECRET", raising=False)
-
     client = AsyncStream(
         api_key="k",
         api_secret="s",
-        base_url="https://example.invalid/",
-        transport=transport,
+        base_url=httpserver.url_for("/"),
+        request_timeout=0.2,
     )
     try:
         with pytest.raises(StreamTransportException) as info:
             await client.get_app()
         assert info.value.error_type == TRANSPORT_ERROR_TIMEOUT
-        assert isinstance(info.value.__cause__, httpx.ReadTimeout)
+        assert isinstance(
+            info.value.__cause__, (httpx.ReadTimeout, httpx.TimeoutException)
+        )
     finally:
         await client.aclose()
 
@@ -415,69 +429,99 @@ def test_legacy_alias_catches_new_exception():
 # ── wait_for_task (§8) ────────────────────────────────────────────────
 
 
-class _FakeError:
-    def __init__(self, type_: str, description: str, stack=None, version=None):
-        self.type = type_
-        self.description = description
-        self.stacktrace = stack
-        self.version = version
+_FIXED_NS = int(datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp() * 1e9)
 
 
-class _FakeTaskData:
-    def __init__(self, status: str, error: Optional[_FakeError] = None):
-        self.status = status
-        self.error = error
+def _task_response(status: str, error: Optional[dict] = None) -> dict:
+    """Build a get-task response body matching the real API shape.
+    `created_at` / `updated_at` are nanosecond Unix timestamps per the
+    backend's wire format."""
+    body: dict = {
+        "duration": "1ms",
+        "task_id": "t",
+        "status": status,
+        "created_at": _FIXED_NS,
+        "updated_at": _FIXED_NS,
+    }
+    if error is not None:
+        body["error"] = error
+    return body
 
 
-class _FakeResponse:
-    def __init__(self, status: str, error: Optional[_FakeError] = None):
-        self.data = _FakeTaskData(status, error)
+def _client_against(httpserver, monkeypatch):
+    """Real ``Stream`` instance pointing at the loopback ``httpserver``."""
+    from getstream import Stream
+
+    monkeypatch.delenv("STREAM_API_KEY", raising=False)
+    monkeypatch.delenv("STREAM_API_SECRET", raising=False)
+    return Stream(
+        api_key="k",
+        api_secret="s",
+        base_url=httpserver.url_for("/"),
+    )
 
 
-class _FakeSyncClient:
-    """Sync stand-in for a ``Stream`` client; ``get_task`` returns the next
-    scripted response, repeating the last one indefinitely once the list is
-    drained so timeout tests don't run out of mock data."""
+def _async_client_against(httpserver, monkeypatch):
+    from getstream import AsyncStream
 
-    def __init__(self, responses):
-        self._responses = list(responses)
-        self.calls = 0
-
-    def get_task(self, *, id):
-        self.calls += 1
-        if len(self._responses) > 1:
-            return self._responses.pop(0)
-        return self._responses[0]
+    monkeypatch.delenv("STREAM_API_KEY", raising=False)
+    monkeypatch.delenv("STREAM_API_SECRET", raising=False)
+    return AsyncStream(
+        api_key="k",
+        api_secret="s",
+        base_url=httpserver.url_for("/"),
+    )
 
 
-class _FakeAsyncClient:
-    def __init__(self, responses):
-        self._responses = list(responses)
-        self.calls = 0
+def test_wait_for_task_sync_returns_on_completed(httpserver, monkeypatch):
+    """The helper exits the polling loop the first time the server reports
+    ``status='completed'``."""
+    bodies = iter(
+        [
+            _task_response("waiting"),
+            _task_response("completed"),
+        ]
+    )
+    from werkzeug.wrappers import Response as WerkzeugResponse
 
-    async def get_task(self, *, id):
-        self.calls += 1
-        if len(self._responses) > 1:
-            return self._responses.pop(0)
-        return self._responses[0]
+    def handler(_r):
+        return WerkzeugResponse(
+            json.dumps(next(bodies)),
+            status=200,
+            content_type="application/json",
+        )
 
+    httpserver.expect_request("/api/v2/tasks/task-1").respond_with_handler(handler)
 
-def test_wait_for_task_sync_returns_on_completed():
-    from getstream.tasks import wait_for_task_sync
-
-    client = _FakeSyncClient([_FakeResponse("waiting"), _FakeResponse("completed")])
-    result = wait_for_task_sync(client, "task-1", poll_interval=0.0, timeout=5.0)
+    client = _client_against(httpserver, monkeypatch)
+    try:
+        result = client.wait_for_task("task-1", poll_interval=0.0, timeout=5.0)
+    finally:
+        client.close()
     assert result.data.status == "completed"
-    assert client.calls == 2
 
 
-def test_wait_for_task_sync_raises_on_failed():
-    from getstream.tasks import wait_for_task_sync
+def test_wait_for_task_sync_raises_on_failed(httpserver, monkeypatch):
+    """A ``status='failed'`` response surfaces as ``StreamTaskException``
+    populated from the task's ``ErrorResult``."""
+    httpserver.expect_request("/api/v2/tasks/task-fail").respond_with_json(
+        _task_response(
+            "failed",
+            error={
+                "type": "ImportFailed",
+                "description": "bad rows",
+                "stacktrace": "trace",
+                "version": "v1",
+            },
+        )
+    )
 
-    err = _FakeError("ImportFailed", "bad rows", stack="trace", version="v1")
-    client = _FakeSyncClient([_FakeResponse("failed", err)])
-    with pytest.raises(StreamTaskException) as info:
-        wait_for_task_sync(client, "task-fail", poll_interval=0.0, timeout=5.0)
+    client = _client_against(httpserver, monkeypatch)
+    try:
+        with pytest.raises(StreamTaskException) as info:
+            client.wait_for_task("task-fail", poll_interval=0.0, timeout=5.0)
+    finally:
+        client.close()
     exc = info.value
     assert exc.task_id == "task-fail"
     assert exc.error_type == "ImportFailed"
@@ -486,44 +530,86 @@ def test_wait_for_task_sync_raises_on_failed():
     assert exc.version == "v1"
 
 
-def test_wait_for_task_sync_times_out_raises_transport_exception():
-    from getstream.tasks import wait_for_task_sync
+def test_wait_for_task_sync_times_out_raises_transport_exception(
+    httpserver, monkeypatch
+):
+    """A perpetually-waiting task causes the helper to raise
+    ``StreamTransportException`` with ``error_type='timeout'``."""
+    httpserver.expect_request("/api/v2/tasks/task-timeout").respond_with_json(
+        _task_response("waiting")
+    )
 
-    # Always 'waiting' — must time out.
-    client = _FakeSyncClient([_FakeResponse("waiting") for _ in range(50)])
-    with pytest.raises(StreamTransportException) as info:
-        wait_for_task_sync(client, "task-timeout", poll_interval=0.0, timeout=0.01)
+    client = _client_against(httpserver, monkeypatch)
+    try:
+        with pytest.raises(StreamTransportException) as info:
+            client.wait_for_task("task-timeout", poll_interval=0.05, timeout=0.15)
+    finally:
+        client.close()
     assert info.value.error_type == TRANSPORT_ERROR_TIMEOUT
 
 
-async def test_wait_for_task_async_returns_on_completed():
-    from getstream.tasks import wait_for_task_async
+async def test_wait_for_task_async_returns_on_completed(httpserver, monkeypatch):
+    bodies = iter(
+        [
+            _task_response("waiting"),
+            _task_response("completed"),
+        ]
+    )
+    from werkzeug.wrappers import Response as WerkzeugResponse
 
-    client = _FakeAsyncClient([_FakeResponse("waiting"), _FakeResponse("completed")])
-    result = await wait_for_task_async(client, "task-1", poll_interval=0.0, timeout=5.0)
+    def handler(_r):
+        return WerkzeugResponse(
+            json.dumps(next(bodies)),
+            status=200,
+            content_type="application/json",
+        )
+
+    httpserver.expect_request("/api/v2/tasks/task-1").respond_with_handler(handler)
+
+    client = _async_client_against(httpserver, monkeypatch)
+    try:
+        result = await client.wait_for_task("task-1", poll_interval=0.0, timeout=5.0)
+    finally:
+        await client.aclose()
     assert result.data.status == "completed"
 
 
-async def test_wait_for_task_async_raises_on_failed():
-    from getstream.tasks import wait_for_task_async
+async def test_wait_for_task_async_raises_on_failed(httpserver, monkeypatch):
+    httpserver.expect_request("/api/v2/tasks/task-fail").respond_with_json(
+        _task_response(
+            "failed",
+            error={
+                "type": "ImportFailed",
+                "description": "async bad",
+                "stacktrace": None,
+                "version": None,
+            },
+        )
+    )
 
-    err = _FakeError("ImportFailed", "async bad", stack=None, version=None)
-    client = _FakeAsyncClient([_FakeResponse("failed", err)])
-
-    with pytest.raises(StreamTaskException) as info:
-        await wait_for_task_async(client, "task-fail", poll_interval=0.0, timeout=5.0)
+    client = _async_client_against(httpserver, monkeypatch)
+    try:
+        with pytest.raises(StreamTaskException) as info:
+            await client.wait_for_task("task-fail", poll_interval=0.0, timeout=5.0)
+    finally:
+        await client.aclose()
     assert info.value.task_id == "task-fail"
     assert info.value.description == "async bad"
 
 
-async def test_wait_for_task_async_times_out_raises_transport_exception():
-    from getstream.tasks import wait_for_task_async
+async def test_wait_for_task_async_times_out_raises_transport_exception(
+    httpserver, monkeypatch
+):
+    httpserver.expect_request("/api/v2/tasks/task-timeout").respond_with_json(
+        _task_response("waiting")
+    )
 
-    client = _FakeAsyncClient([_FakeResponse("waiting") for _ in range(50)])
-    with pytest.raises(StreamTransportException) as info:
-        await wait_for_task_async(
-            client, "task-timeout", poll_interval=0.0, timeout=0.01
-        )
+    client = _async_client_against(httpserver, monkeypatch)
+    try:
+        with pytest.raises(StreamTransportException) as info:
+            await client.wait_for_task("task-timeout", poll_interval=0.05, timeout=0.15)
+    finally:
+        await client.aclose()
     assert info.value.error_type == TRANSPORT_ERROR_TIMEOUT
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -951,6 +951,7 @@ dev = [
     { name = "prometheus-client" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-httpserver" },
     { name = "pytest-timeout" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -1011,6 +1012,7 @@ dev = [
     { name = "prometheus-client", specifier = ">=0.23.1" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
+    { name = "pytest-httpserver", specifier = ">=1.1.5" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "python-dateutil", specifier = ">=2.8.2,<3" },
@@ -2861,6 +2863,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpserver"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/17/ad187f46998814014f7cda309de700b87c0eb4b2e111e18bc8c819be7116/pytest_httpserver-1.1.5.tar.gz", hash = "sha256:dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1", size = 70974, upload-time = "2026-02-14T13:27:23.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/df/0bdf90b84c6a586a9fd2b509523a3ab26b1cc1b1dba2fb62a32e4411ea9e/pytest_httpserver-1.1.5-py3-none-any.whl", hash = "sha256:ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a", size = 23330, upload-time = "2026-02-14T13:27:22.119Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3684,6 +3698,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New error classes (importable from `getstream` or `getstream.exceptions`):
  - `StreamException` (abstract base)
  - `StreamApiException` — HTTP 4xx/5xx, full APIError envelope including `unrecoverable` and `exception_fields`
  - `StreamRateLimitException` — HTTP 429, adds `retry_after: timedelta | None`
  - `StreamTransportException` — network failures, `error_type` enum, `__cause__` preserved
  - `StreamTaskException` — for `wait_for_task` failures
- `Stream.wait_for_task(...)` (sync) and `AsyncStream.wait_for_task(...)` (async). 1s poll, 60s timeout by default.
- Transport-layer `httpx.RequestError` is wrapped at the SDK boundary in both sync and async paths.
- `Retry-After` parsing covers integer seconds and HTTP-date; past dates clamp to zero; missing / garbage → `None`.

## Back-compat

`getstream.base.StreamAPIException` (capital `API`) preserved as an alias for one minor cycle via module-level `__getattr__` that emits `DeprecationWarning`. Same class object as the new spelling, so `pytest.raises(StreamAPIException)`, `except StreamAPIException`, and `isinstance(...)` keep working.

## Test plan

- [ ] `uv run pytest tests/test_exceptions.py`
- [ ] `uv run pytest` (full suite)
- [ ] `uv run ruff check .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized exception hierarchy exported at package level (API, rate-limit, transport, task)
  * Task polling helpers (sync & async) that return completed results, raise task errors on failure, and signal timeout as transport timeout
  * Webhook helper primitives and client-backed webhook methods
  * Connection pooling/timeouts with effective config logged

* **Changed**
  * Network/request errors are wrapped and classified as transport exceptions; Retry-After is parsed for rate limits; default request timeout updated

* **Deprecated**
  * Legacy exception name preserved with deprecation warning

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-py/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->