### PR TITLE
chore: derive release bump only from the title bang marker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,9 @@ jobs:
         if: github.event_name == 'pull_request' && steps.already_released.outputs.value != 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_BODY_FILE=$(mktemp)
-          printf '%s' "$PR_BODY" > "$PR_BODY_FILE"
           python3 scripts/release/bump_version.py \
             --title "$PR_TITLE" \
-            --body-file "$PR_BODY_FILE" \
             --output "$GITHUB_OUTPUT"
 
       - name: Determine version bump (manual)

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -65,12 +65,11 @@ def find_latest_semver_tag() -> str:
     return "{}.{}.{}".format(*versions[-1])
 
 
-def determine_bump_type(title: str, body: str) -> str:
+def determine_bump_type(title: str) -> str:
+    # Breaking changes are signalled only by the `!` marker in the title
+    # (e.g. `feat!:`). Free-text body/title prose is not trusted: a PR that
+    # merely mentions "BREAKING CHANGE" must not force a major bump.
     title = title.strip()
-    body = body.strip()
-    breaking_re = re.compile(r"BREAKING[ -]CHANGES?", re.IGNORECASE)
-    if breaking_re.search(title) or breaking_re.search(body):
-        return "major"
     match = re.match(r"^([a-zA-Z]+)(\([^)]+\))?(!)?:", title)
     if not match:
         return "none"
@@ -119,12 +118,6 @@ def parse_bool(value: str) -> bool:
     return value.strip().lower() == "true"
 
 
-def resolve_body(args: argparse.Namespace) -> str:
-    if args.body_file:
-        return Path(args.body_file).read_text(encoding="utf-8")
-    return args.body or ""
-
-
 def write_outputs(output_path: str, entries: dict[str, str]) -> None:
     if not output_path:
         for key, value in entries.items():
@@ -138,8 +131,6 @@ def write_outputs(output_path: str, entries: dict[str, str]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--title", default="")
-    parser.add_argument("--body", default="")
-    parser.add_argument("--body-file", dest="body_file", default="")
     parser.add_argument("--output", default="")
     parser.add_argument("--manual-bump", dest="manual_bump", default="")
     parser.add_argument(
@@ -174,8 +165,7 @@ def main() -> int:
         )
         return 0
 
-    body = resolve_body(args)
-    bump = determine_bump_type(args.title, body)
+    bump = determine_bump_type(args.title)
     if bump == "none":
         write_outputs(
             args.output,


### PR DESCRIPTION
## Problem
`scripts/release/bump_version.py` (`determine_bump_type`) forced a major bump whenever the substring "BREAKING CHANGE(S)" appeared anywhere in the PR title or body (`/BREAKING[ -]CHANGES?/i` over free text). Any PR that merely *mentions* the phrase, including a sentence saying there is none, trips it. This is the same footgun that mis-cut a major release in getstream-ruby.

## Fix
Trust only the conventional-commits `!` marker in the title (e.g. `feat!:`) as the breaking-change signal. Stop reading the PR body entirely, and remove the now-dead `--body` / `--body-file` options plus the body plumbing in `release.yml`.

Bump rules after this change (title-only):
- `feat!:` / `fix!:` / `type(scope)!:` -> major
- `feat:` -> minor
- `fix:` / `bug:` -> patch
- anything else -> no release

## Release note
This PR is intentionally titled `feat:` so the auto-release cuts a **minor** (latest tag `v3.4.0` -> `v3.5.0`), which matches the `version = "3.5.0"` already set in `pyproject.toml` and publishes the features merged since v3.4.0. A `fix:` title would have computed `3.4.1` and regressed `pyproject`.

## Verification
Loaded the real module and tested `determine_bump_type` directly:
- `feat:` -> minor, `feat!:` / `feat(mod)!:` / `fix!:` -> major, `fix:` / `bug:` -> patch, `chore:` -> none
- `feat: mentions BREAKING CHANGE in prose` -> **minor** (the regression), `BREAKING CHANGES: prose title` -> none

`ruff check` and `ruff format --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the release version-bump determination process to rely solely on PR title indicators, removing unnecessary PR body extraction from the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->