### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ "**" ]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   unit:
     uses: ./.github/workflows/run_tests.yml

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,6 +15,9 @@ env:
   # If set, uv will run without updating the uv.lock file. Equivalent to the `uv run --frozen`.
   UV_FROZEN: "1"
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     name: Ruff


### PR DESCRIPTION
## Summary
- Add explicit least-privilege permissions blocks to 2 workflows.
- Resolves 5 open CodeQL actions/missing-workflow-permissions alerts.

## Linear
- [APPSEC-210](https://linear.app/stream/issue/APPSEC-210)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened GitHub Actions permissions in CI and test workflows to use read-only access where possible.
  * Improved workflow security by explicitly limiting token access for repository contents and pull request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->