### PR TITLE
feat: release structured logging and opt-in auto-retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-07-24
+
 ### Added
 
 - Standardized error hierarchy ([CHA-2958](https://linear.app/stream/issue/CHA-2958)).


### PR DESCRIPTION
Release PR: stamps the accumulated `[Unreleased]` changelog as **v4.2.0**; on merge the release workflow bumps the version, tags, and publishes.

Minor bump: the changelog records no breaking changes. Ships structured logging (opt-in logger + body logging, always-on secret redaction) and opt-in auto-retries via `RetryConfig`, plus the other accumulated unreleased changes. (Heads-up: the client `request_timeout` default moved 6s to 30s, classified non-breaking.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for the 4.2.0 release dated July 24, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->