### PR TITLE
feat: name the HTTP status when the error body is not JSON

### DIFF
--- a/getstream/exceptions.py
+++ b/getstream/exceptions.py
@@ -36,10 +36,10 @@ class StreamException(Exception):
 class StreamApiException(StreamException):
     """Raised on any HTTP 4xx/5xx response from the Stream API.
 
-    Raised with code=0 and message='failed to parse error response' when an
-    HTTP response was received but the body could not be parsed as an
-    APIError envelope; in that case ``__cause__`` carries the underlying
-    parse error.
+    Raised with code=0 and message='failed to parse error response: unexpected
+    server response code <status>' when an HTTP response was received but the
+    body could not be parsed as an APIError envelope; in that case ``__cause__``
+    carries the underlying parse error.
     """
 
     def __init__(
@@ -205,7 +205,7 @@ def _fields_from_response(
         {
             "status_code": response.status_code,
             "code": 0,
-            "message": "failed to parse error response",
+            "message": f"failed to parse error response: unexpected server response code {response.status_code}",
             "exception_fields": {},
             "unrecoverable": False,
             "raw_response_body": raw_body,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -152,7 +152,10 @@ def test_api_exception_unparseable_body_falls_back_per_spec_6_3():
     exc = build_api_exception(response)
     assert exc.status_code == 500
     assert exc.code == 0
-    assert exc.message == "failed to parse error response"
+    assert (
+        exc.message
+        == "failed to parse error response: unexpected server response code 500"
+    )
     assert exc.exception_fields == {}
     assert exc.unrecoverable is False
     assert exc.raw_response_body == "<html>upstream barfed</html>"

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -891,7 +895,7 @@ wheels = [
 
 [[package]]
 name = "getstream"
-version = "3.5.0"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "dataclasses-json" },


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-4641/generated-sdks-report-the-http-status-when-the-error-body-is-not-json

## Summary
When an error body is not JSON, the SDK reported only the parse failure and hid the HTTP status. A customer saw `failed to parse error response` for a 503 that the edge proxy returned as plain text, plus a JSON parse stack trace, and could not tell which status they got. `StreamApiException.message` now appends the status: `failed to parse error response: unexpected server response code 503`. `status_code`, `raw_response_body` and `__cause__` do not change.

The old text is still the prefix of the new message, so prefix matching and substring matching on it both keep working.

## Verification
- `make lint`: ruff check and format clean.
- `uv run pytest tests/test_exceptions.py tests/test_retry.py`: 53 passed.
- `make typecheck`: 61 diagnostics, the same count as the base commit.
